### PR TITLE
27 extension generate module name into UI trees

### DIFF
--- a/core/UITreeGenerator.py
+++ b/core/UITreeGenerator.py
@@ -7,7 +7,7 @@ from TerminologService.ValueSetResolver import get_term_entries_from_onto_server
 from core.ResourceQueryingMetaDataResolver import ResourceQueryingMetaDataResolver
 from helper import is_structure_definition
 from model.ResourceQueryingMetaData import ResourceQueryingMetaData
-from model.UiDataModel import TermEntry, TermCode
+from model.UiDataModel import TermEntry, TermCode, Module
 
 
 class UITreeGenerator(ResourceQueryingMetaDataResolver):
@@ -78,7 +78,10 @@ class UITreeGenerator(ResourceQueryingMetaDataResolver):
                 print(f"Term code defining id: {applicable_querying_meta_data.term_code_defining_id}")
                 sub_tree = self.get_term_entries_by_id(fhir_profile_snapshot, applicable_querying_meta_data.
                                                        term_code_defining_id)
+                module_definition = applicable_querying_meta_data.module
+                module_instance = Module(module_definition.get('code'), module_definition.get('display'))
                 self.set_context(sub_tree, applicable_querying_meta_data.context)
+                self.set_module(sub_tree, module_instance)
                 result += sub_tree
             elif applicable_querying_meta_data.term_codes:
                 result += [
@@ -90,6 +93,12 @@ class UITreeGenerator(ResourceQueryingMetaDataResolver):
             entry.context = context
             if entry.children:
                 self.set_context(entry.children, context)
+
+    def set_module(self, entries: List[TermEntry], module: Module):
+        for entry in entries:
+            entry.module = module
+            if entry.children:
+                self.set_module(entry.children, module)
 
     def generate_module_ui_tree(self, module_name, files: List[str]) -> TermEntry:
         """

--- a/example/new_module_template/generate_ontology.py
+++ b/example/new_module_template/generate_ontology.py
@@ -304,6 +304,7 @@ if __name__ == '__main__':
     if args.generate_ui_trees:
         log.info(f"# Generating UI Trees...")
         tree_generator = UITreeGenerator(resolver)
+        differential_folder = "resources/differential"
         ui_trees = tree_generator.generate_ui_trees(differential_folder)
         write_ui_trees_to_files(ui_trees, f'{onto_result_dir}/ui-trees')
 

--- a/example/new_module_template/resources/QueryingMetaData/Beatmung.json
+++ b/example/new_module_template/resources/QueryingMetaData/Beatmung.json
@@ -1,6 +1,10 @@
 {
   "name": "Beatmung",
   "resource_type": "Procedure",
+  "module": {
+    "code": "mii-icu",
+    "display": "ICU"
+  },
   "context": {
     "system": "mii.icu",
     "code": "ICU",

--- a/model/ResourceQueryingMetaData.py
+++ b/model/ResourceQueryingMetaData.py
@@ -4,7 +4,7 @@ import json
 from typing import List, Dict
 
 from model.helper import del_none
-from model.UiDataModel import TermCode
+from model.UiDataModel import TermCode, Module
 
 
 class ResourceQueryingMetaData:
@@ -26,7 +26,7 @@ class ResourceQueryingMetaData:
     overwritten here.
     :param time_restriction_defining_id defines the id that identifies the time restriction element.
     """
-    def __init__(self, name: str, resource_type: str, context: TermCode | dict, term_code_defining_id: str = None,
+    def __init__(self, name: str, resource_type: str, module: dict, context: TermCode | dict, term_code_defining_id: str = None,
                  term_codes: List[TermCode] | List[dict] = None, value_defining_id: str = None, value_type: str = None,
                  attribute_defining_id_type_map: Dict[str, str] = None, time_restriction_defining_id: str = None):
         self.name = name
@@ -38,6 +38,7 @@ class ResourceQueryingMetaData:
         self.value_defining_id = value_defining_id
         self.attribute_defining_id_type_map = attribute_defining_id_type_map if attribute_defining_id_type_map else {}
         self.time_restriction_defining_id = time_restriction_defining_id
+        self.module = module
 
     def to_json(self):
         """

--- a/model/UiDataModel.py
+++ b/model/UiDataModel.py
@@ -152,6 +152,13 @@ class Unit:
         self.code = code
 
 
+class Module:
+
+    def __init__(self, code, display):
+        self.code = code
+        self.display = display
+
+
 class TermEntry(object):
     DO_NOT_SERIALIZE = ["terminologyType", "path", "DO_NOT_SERIALIZE", "fhirMapperType", "termCode", "valueDefinitions",
                         "root"]
@@ -168,7 +175,7 @@ class TermEntry(object):
     # TODO: context should be after term_codes. This would be a breaking change -> requires updating all uses of this \
     # class
     def __init__(self, term_codes: List[TermCode], terminology_type=None, leaf=True,
-                 selectable=True, context: TermCode = None, ui_profile=None):
+                 selectable=True, context: TermCode = None, ui_profile=None, module: Module = None):
         self.id = str(uuid.UUID(int=rd.getrandbits(128)))
         self.termCodes = term_codes
         self.termCode = term_codes[0]
@@ -183,6 +190,7 @@ class TermEntry(object):
         self.display = (self.termCode.display if self.termCode else None)
         self.root = True
         self.context = context
+        self.module = module
 
     def __lt__(self, other):
         if self.display and other.display:


### PR DESCRIPTION
1. Introduced a new data class `Module` to represent key-value pairs, with fields for `display `and `code`


2. Iterating over Ui_tree `entries`, injecting `Module `data objects into the tree structure.