### PR TITLE
#43 - Add Delete tables to each ontology db dump

### DIFF
--- a/example/mii_core_data_set/resources/delete_statements.sql
+++ b/example/mii_core_data_set/resources/delete_statements.sql
@@ -1,0 +1,12 @@
+DELETE FROM public.criteria_set;
+DELETE FROM public.contextualized_termcode;
+DELETE FROM public.contextualized_termcode_to_criteria_set;
+DELETE FROM public.ui_profile;
+DELETE FROM public.mapping;
+DELETE FROM public.context;
+DELETE FROM public.termcode;
+ALTER SEQUENCE public.criteria_set_id_seq RESTART WITH 1;
+ALTER SEQUENCE public.ui_profile_id_seq RESTART WITH 1;
+ALTER SEQUENCE public.mapping_id_seq RESTART WITH 1;
+ALTER SEQUENCE public.context_id_seq RESTART WITH 1;
+ALTER SEQUENCE public.termcode_id_seq RESTART WITH 1;


### PR DESCRIPTION
- add function that inserts the contents of a given file at a specific place in another file
- this should be revisited when #18 is merged, so that the sql file and the method to insert content into files can be put in one shared place