### PR TITLE
Improve system independence by relying on system-specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ dependencies
 /.git/
 availability/*.json
 !availability/stratum-to-context.json
+
+.commit

--- a/core/UIProfileGenerator.py
+++ b/core/UIProfileGenerator.py
@@ -315,7 +315,7 @@ class UIProfileGenerator:
         :param module_dir: module directory of the profile
         :return: referenced context
         """
-        module_name = module_dir.replace("package", "").split("/")[-1]
+        module_name = module_dir.replace("package", "").split(os.sep)[-1]
         return self.querying_meta_data_resolver.get_query_meta_data(profile_snapshot,
                                                                     module_name)[0].context
 

--- a/example/mii_core_data_set/fhirpkg.lock.json
+++ b/example/mii_core_data_set/fhirpkg.lock.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2024-09-24T21:09:22.823235+02:00",
+  "updated": "2024-09-25T14:04:59.8995011+02:00",
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
     "de.medizininformatikinitiative.kerndatensatz.medikation": "2.0.0",
@@ -11,7 +11,8 @@
     "de.einwilligungsmanagement": "1.0.1",
     "de.medizininformatikinitiative.kerndatensatz.laborbefund": "1.0.6",
     "de.medizininformatikinitiative.kerndatensatz.diagnose": "2024.0.0",
-    "de.medizininformatikinitiative.kerndatensatz.fall": "2024.0.1"
+    "de.medizininformatikinitiative.kerndatensatz.fall": "2024.0.1",
+    "de.medizininformatikinitiative.kerndatensatz.biobank": "1.0.1"
   },
   "missing": {}
 }

--- a/example/mii_core_data_set/package.json
+++ b/example/mii_core_data_set/package.json
@@ -12,6 +12,7 @@
     "de.medizininformatikinitiative.kerndatensatz.consent": "1.0.4",
     "de.medizininformatikinitiative.kerndatensatz.laborbefund": "1.0.6",
     "de.medizininformatikinitiative.kerndatensatz.diagnose": "2024.0.0",
-    "de.medizininformatikinitiative.kerndatensatz.fall": "2024.0.1"
+    "de.medizininformatikinitiative.kerndatensatz.fall": "2024.0.1",
+    "de.medizininformatikinitiative.kerndatensatz.biobank": "1.0.1"
   }
 }


### PR DESCRIPTION
path separators
[issue:78]

UIProfileGenerator:
  - Fix issue on Windows machines caused by hardcoded Unix path separators