### PR TITLE
#88 - Consider "-" when searching for codes

### DIFF
--- a/example/fdpg-ontology/elastic-additional-files/codeable_concept_index.json
+++ b/example/fdpg-ontology/elastic-additional-files/codeable_concept_index.json
@@ -18,8 +18,16 @@
           "token_chars": [
             "letter",
             "digit",
-            "punctuation"
+            "punctuation",
+            "custom"
+          ],
+          "custom_token_chars": [
+            "+-_"
           ]
+        },
+        "whitespace_tokenizer": {
+          "type": "simple_pattern_split",
+          "pattern": " "
         }
       },
       "analyzer": {
@@ -39,7 +47,7 @@
         },
         "lowercase_analyzer": {
           "type": "custom",
-          "tokenizer": "standard",
+          "tokenizer": "whitespace_tokenizer",
           "filter": [
             "lowercase"
           ]

--- a/example/fdpg-ontology/elastic-additional-files/ontology_index.json
+++ b/example/fdpg-ontology/elastic-additional-files/ontology_index.json
@@ -18,8 +18,16 @@
           "token_chars": [
             "letter",
             "digit",
-            "punctuation"
+            "punctuation",
+            "custom"
+          ],
+          "custom_token_chars": [
+            "+-_"
           ]
+        },
+        "whitespace_tokenizer": {
+          "type": "simple_pattern_split",
+          "pattern": " "
         }
       },
       "analyzer": {
@@ -39,7 +47,7 @@
         },
         "lowercase_analyzer": {
           "type": "custom",
-          "tokenizer": "standard",
+          "tokenizer": "whitespace_tokenizer",
           "filter": [
             "lowercase"
           ]


### PR DESCRIPTION
- include "+", "-" and "_" in the tokens for the edge_ngram tokenizer
- change the tokenizer in the search_analyzer from lowercase to a pattern split tokenizer that only splits on whitespace (not on hyphens)