### PR TITLE
#135 - Change tokenizer for display names in elastic search

### DIFF
--- a/example/fdpg-ontology/elastic-additional-files/codeable_concept_index.json
+++ b/example/fdpg-ontology/elastic-additional-files/codeable_concept_index.json
@@ -8,15 +8,6 @@
           "max_gram": 20,
           "token_chars": [
             "letter",
-            "digit"
-          ]
-        },
-        "edge_ngram_tokenizer_include_punctuation": {
-          "type": "edge_ngram",
-          "min_gram": 1,
-          "max_gram": 20,
-          "token_chars": [
-            "letter",
             "digit",
             "punctuation",
             "custom"
@@ -38,13 +29,6 @@
             "lowercase"
           ]
         },
-        "edge_ngram_analyzer_include_punctuation": {
-          "type": "custom",
-          "tokenizer": "edge_ngram_tokenizer_include_punctuation",
-          "filter": [
-            "lowercase"
-          ]
-        },
         "lowercase_analyzer": {
           "type": "custom",
           "tokenizer": "whitespace_tokenizer",
@@ -61,7 +45,7 @@
         "properties": {
           "code": {
             "type": "text",
-            "analyzer": "edge_ngram_analyzer_include_punctuation",
+            "analyzer": "edge_ngram_analyzer",
             "search_analyzer": "lowercase_analyzer"
           },
           "display": {

--- a/example/fdpg-ontology/elastic-additional-files/ontology_index.json
+++ b/example/fdpg-ontology/elastic-additional-files/ontology_index.json
@@ -8,15 +8,6 @@
           "max_gram": 20,
           "token_chars": [
             "letter",
-            "digit"
-          ]
-        },
-        "edge_ngram_tokenizer_include_punctuation": {
-          "type": "edge_ngram",
-          "min_gram": 1,
-          "max_gram": 20,
-          "token_chars": [
-            "letter",
             "digit",
             "punctuation",
             "custom"
@@ -34,13 +25,6 @@
         "edge_ngram_analyzer": {
           "type": "custom",
           "tokenizer": "edge_ngram_tokenizer",
-          "filter": [
-            "lowercase"
-          ]
-        },
-        "edge_ngram_analyzer_include_punctuation": {
-          "type": "custom",
-          "tokenizer": "edge_ngram_tokenizer_include_punctuation",
           "filter": [
             "lowercase"
           ]
@@ -129,7 +113,7 @@
       },
       "termcode": {
         "type": "text",
-        "analyzer": "edge_ngram_analyzer_include_punctuation",
+        "analyzer": "edge_ngram_analyzer",
         "search_analyzer": "lowercase_analyzer"
       },
       "termcodes": {


### PR DESCRIPTION
- use the same edge ngram tokenizer (including punctuation, '+', '-' and '_') for display names as well as codes