### PR TITLE
Implement type emission for time restriction in CQL mapping

### DIFF
--- a/combined-consent-generation.py
+++ b/combined-consent-generation.py
@@ -2,7 +2,7 @@ import csv
 import json
 from model.helper import del_none
 from model.UiDataModel import TermCode
-from model.MappingDataModel import FhirMapping, FixedFHIRCriteria
+from model.MappingDataModel import FhirMapping, FixedFHIRCriteria, CQLTimeRestrictionParameter
 from model.MappingDataModel import CQLMapping, FixedCQLCriteria
 from model.TreeMap import TreeMap, TermEntryNode
 import argparse
@@ -83,7 +83,7 @@ def process_csv(csv_file: str):
             fhir_mapping.timeRestrictionParameter = "date"
             cql_mapping.key = term_code
             cql_mapping.context = context
-            cql_mapping.timeRestrictionFhirPath = "Consent.datetime"
+            cql_mapping.timeRestriction = CQLTimeRestrictionParameter("Consent.datetime", ["dateTime"])
             cql_mapping.resourceType = "Consent"
             cql_mapping.primaryCode= {
                             "code": "57016-8",

--- a/core/exceptions/UnsupportedTypingException.py
+++ b/core/exceptions/UnsupportedTypingException.py
@@ -1,0 +1,6 @@
+class UnsupportedTypingException(Exception):
+    """
+    This exception represent a mismatch between the present range of types supported by two different elements or
+    objects in general.
+    """
+    pass

--- a/example/mii_core_data_set/generate_ontology.py
+++ b/example/mii_core_data_set/generate_ontology.py
@@ -433,13 +433,16 @@ def generate_cql_mapping(
     :param onto_result_dir: The base directory for output files.
     :param logger: The logger object.
     """
-    logger.info("Generating CQL mapping...")
-    cql_generator = CQLMappingGenerator(resolver)
-    cql_term_code_mappings, cql_concept_mappings = cql_generator.generate_mapping(differential_folder, module_name)
-    cql_mappings = denormalize_mapping_to_old_format(cql_term_code_mappings, cql_concept_mappings)
-    cql_mapping_file = os.path.join(onto_result_dir, 'mapping', 'cql', 'mapping_cql.json')
-    with open(cql_mapping_file, 'w', encoding='utf-8') as f:
-        f.write(cql_mappings.to_json())
+    try:
+        logger.info("Generating CQL mapping...")
+        cql_generator = CQLMappingGenerator(resolver)
+        cql_term_code_mappings, cql_concept_mappings = cql_generator.generate_mapping(differential_folder, module_name)
+        cql_mappings = denormalize_mapping_to_old_format(cql_term_code_mappings, cql_concept_mappings)
+        cql_mapping_file = os.path.join(onto_result_dir, 'mapping', 'cql', 'mapping_cql.json')
+        with open(cql_mapping_file, 'w', encoding='utf-8') as f:
+            f.write(cql_mappings.to_json())
+    except Exception as exc:
+        raise Exception("CQL mapping generation failed. No mapping will be emitted", exc)
 
 
 def generate_fhir_mapping(
@@ -528,7 +531,7 @@ def main():
                     resolver, os.path.join("CDS_Module", module, "differential"), os.path.join("CDS_Module", module, onto_result_dir), StandardSearchParameterResolver(module), module, logger
                 )
         except Exception as e:
-            logger.error(f"An error occurred: {e}", exc_info=True)
+            logger.error(f"An error occurred while running generator for module '{module}': {e}", exc_info=True)
         finally:
             # Dump the database to the module's directory
             if args.generate_ui_profiles:

--- a/example/mii_core_data_set_old/generate_cds.py
+++ b/example/mii_core_data_set_old/generate_cds.py
@@ -23,7 +23,8 @@ from core.docker.Images import POSTGRES_IMAGE
 from database.DataBaseWriter import DataBaseWriter
 from helper import download_simplifier_packages, generate_snapshots, write_object_as_json, load_querying_meta_data, \
     mkdir_if_not_exists
-from model.MappingDataModel import CQLMapping, FhirMapping, MapEntryList, FixedFHIRCriteria, PathlingMapping
+from model.MappingDataModel import CQLMapping, FhirMapping, MapEntryList, FixedFHIRCriteria, PathlingMapping, \
+    CQLTimeRestrictionParameter
 from model.ResourceQueryingMetaData import ResourceQueryingMetaData
 from model.TreeMap import ContextualizedTermCodeInfoList, TreeMapList
 from model.UIProfileModel import UIProfile
@@ -402,7 +403,7 @@ def get_combined_consent_fhir_mapping():
 
 def get_combined_consent_cql_mapping():
     combined_consent_cql_mapping = CQLMapping("CombinedConsent")
-    combined_consent_cql_mapping.timeRestrictionFhirPath = "Consent.datetime"
+    combined_consent_cql_mapping.timeRestriction = CQLTimeRestrictionParameter("Consent.datetime", ["dateTime"])
     combined_consent_cql_mapping.fhirResourceType = "Consent"
     primaryCode = TermCode("http://loinc.org", "54133-1", "Consent Document")
     combined_consent_cql_mapping.primaryCode = primaryCode

--- a/model/MappingDataModel.py
+++ b/model/MappingDataModel.py
@@ -111,6 +111,17 @@ class FhirMapping:
 
 
 @dataclass
+class CQLTimeRestrictionParameter:
+    """
+    Holds information about an element within a FHIR resources that a filter targets
+    :param fhirPath: Path to the targeted element as a FHIRPath expression
+    :param types: List of types supported by this element which can be multiple if the element is polymorphic
+    """
+    fhirPath: str
+    types: List[str]
+
+
+@dataclass
 class CQLMapping:
     """
     CQLMapping stores all necessary information to translate a structured query to a CQL query.
@@ -121,7 +132,7 @@ class CQLMapping:
     termCodeFhirPath: Optional[str] = None
     valueFhirPath: Optional[str] = None
     valueType = None
-    timeRestrictionFhirPath: Optional[str] = None
+    timeRestriction: Optional[CQLTimeRestrictionParameter] = None
     attributeFhirPaths: List[CQLAttributeSearchParameter] = field(default_factory=list)
     # only required for version 1 support
     key: Optional[str] = None


### PR DESCRIPTION
[Address #156]
**CQL Mapping Generation:**
  
- Change mapping entry layout: Refactor timeRestrictionFhirPath into timeRestriction object with attributes fhirPath and types holding supported FHIR data types
- Implement extraction of supported types of time restricting element in profile snapshot