### PR TITLE
Fix Elasticsearch tokenizer max N-gram length

### DIFF
--- a/example/fdpg-ontology/elastic-additional-files/codeable_concept_index.json
+++ b/example/fdpg-ontology/elastic-additional-files/codeable_concept_index.json
@@ -5,7 +5,7 @@
         "edge_ngram_tokenizer": {
           "type": "edge_ngram",
           "min_gram": 1,
-          "max_gram": 20,
+          "max_gram": 50,
           "token_chars": [
             "letter",
             "digit"
@@ -14,7 +14,7 @@
         "edge_ngram_tokenizer_include_punctuation": {
           "type": "edge_ngram",
           "min_gram": 1,
-          "max_gram": 20,
+          "max_gram": 50,
           "token_chars": [
             "letter",
             "digit",

--- a/example/fdpg-ontology/elastic-additional-files/ontology_index.json
+++ b/example/fdpg-ontology/elastic-additional-files/ontology_index.json
@@ -5,7 +5,7 @@
         "edge_ngram_tokenizer": {
           "type": "edge_ngram",
           "min_gram": 1,
-          "max_gram": 20,
+          "max_gram": 50,
           "token_chars": [
             "letter",
             "digit"
@@ -14,7 +14,7 @@
         "edge_ngram_tokenizer_include_punctuation": {
           "type": "edge_ngram",
           "min_gram": 1,
-          "max_gram": 20,
+          "max_gram": 50,
           "token_chars": [
             "letter",
             "digit",


### PR DESCRIPTION
## Fix tokenizer token length

### Elasticsearch Index Config:
  - Increase tokenizer max gram length to cover unusally long code tokens such as those used for consent policies