### PR TITLE
Fix generated FHIRPath expressions in CQL mapping

### DIFF
--- a/test/integration/backend/test-queries/Person_Vitalstatus_Patient1_Q1.json
+++ b/test/integration/backend/test-queries/Person_Vitalstatus_Patient1_Q1.json
@@ -1,1 +1,39 @@
-{"version":"http://to_be_decided.com/draft-1/schema#","display":"Ausgewählte Merkmale","inclusionCriteria":[[{"termCodes":[{"code":"67162-8","display":"Patient Disposition","system":"http://loinc.org","version":""}],"context":{"code":"Vitalstatus","display":"Vitalstatus","system":"fdpg.mii.cds","version":"1.0.0"},"timeRestriction":{"afterDate":"2024-02-21","beforeDate":"2024-02-21"},"valueFilter":{"selectedConcepts":[{"code":"T","display":"Patient verstorben","system":"https://www.medizininformatik-initiative.de/fhir/core/modul-person/CodeSystem/Vitalstatus","version":"2099"}],"type":"concept"}}]]}
+{
+  "version": "http://to_be_decided.com/draft-1/schema#",
+  "display": "Ausgewählte Merkmale",
+  "inclusionCriteria": [
+    [
+      {
+        "termCodes": [
+          {
+            "code": "67162-8",
+            "display": "Patient Disposition",
+            "system": "http://loinc.org",
+            "version": ""
+          }
+        ],
+        "context": {
+          "code": "Vitalstatus",
+          "display": "Vitalstatus",
+          "system": "fdpg.mii.cds",
+          "version": "1.0.0"
+        },
+        "timeRestriction": {
+          "afterDate": "2024-02-21",
+          "beforeDate": "2024-02-21"
+        },
+        "valueFilter": {
+          "selectedConcepts": [
+            {
+              "code": "T",
+              "display": "Patient verstorben",
+              "system": "https://www.medizininformatik-initiative.de/fhir/core/modul-person/CodeSystem/Vitalstatus",
+              "version": "2099"
+            }
+          ],
+          "type": "concept"
+        }
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
CQL Mapping:
  - Remove inclusion of FHIR resource type at the start of FHIRPath expressions in the CQL mapping
  - Remove explicit listing of termcode FHIRPath expression and allowed types if it is a primary path according to the ELM FHIR modelinfo