### PR TITLE
Undo changes in FHIRSearch mapping caused by update of CQL mapping

### DIFF
--- a/combined-consent-generation.py
+++ b/combined-consent-generation.py
@@ -7,7 +7,7 @@ from model.TreeMap import TreeMap, TermEntryNode
 import argparse
 import os
 
-from util.codec.json import JSONSetEncoder
+from util.codec.json import JSONFhirOntoEncoder
 
 
 def configure_args_parser():
@@ -47,7 +47,7 @@ def convert_bool_analysis_to_code(distributed_analysis, eu_gdpr, insurance_data,
 
 def generate_fixed_fhir_criteria(provisions_code, provisions_display) -> list[FixedFHIRCriteria]:
 
-    return [FixedFHIRCriteria({"coding"}, "mii-provision-provision-code",
+    return [FixedFHIRCriteria("coding", "mii-provision-provision-code",
             [{"code": code, "display": display, "system": "urn:oid:2.16.840.1.113883.3.1937.777.24.5.3"}])
             for code, display in zip(provisions_code, provisions_display)]
 
@@ -116,7 +116,7 @@ def process_csv(csv_file: str):
 
 def save_json(filename: str, data):
     with open(filename, "w+", encoding='UTF-8') as f:
-        json.dump(data, f, cls=JSONSetEncoder)
+        json.dump(data, f, cls=JSONFhirOntoEncoder)
 
 
 def append_to_json(filename: str, input_filename: str, data):

--- a/core/UIProfileGenerator.py
+++ b/core/UIProfileGenerator.py
@@ -12,7 +12,7 @@ from core.StructureDefinitionParser import InvalidValueTypeException, UCUM_SYSTE
     ProcessedElementResult, get_fixed_term_codes, FHIR_TYPES_TO_VALUE_TYPES, extract_value_type
 from helper import logger, process_element_definition
 from model.ResourceQueryingMetaData import ResourceQueryingMetaData
-from model.UIProfileModel import ValueDefinition, UIProfile, AttributeDefinition, CriteriaSet, VALUE_TYPE_OPTIONS
+from model.UIProfileModel import ValueDefinition, UIProfile, AttributeDefinition, CriteriaSet
 from model.UiDataModel import TermCode
 
 AGE_UNIT_VALUE_SET = "http://hl7.org/fhir/ValueSet/age-units"

--- a/util/codec/json.py
+++ b/util/codec/json.py
@@ -7,9 +7,10 @@ from typing_extensions import Never, Optional
 from model.helper import del_none
 
 
-class JSONSetEncoder(json.JSONEncoder):
+class JSONFhirOntoEncoder(json.JSONEncoder):
     """
-    Custom JSON encoder to enable encoding of Python set instances to JSON arrays
+    Custom JSON encoder for the project which has some additional capabilities such as set encoding and deleting keys
+    without values
     """
     def default(self, o: Any):
         """


### PR DESCRIPTION
Mapping Data Model:
  - Undo changes in FHIRSearch mapping by restructuring inheritance