### PR TITLE
Remove unused tables in SQL dump files

### DIFF
--- a/cohort_selection_ontology/scripts/generate_ontology.py
+++ b/cohort_selection_ontology/scripts/generate_ontology.py
@@ -302,7 +302,6 @@ def generate_ui_profiles(
         contextualized_term_code_ui_profile_mapping, named_ui_profiles_dict
     )
     db_writer.write_vs_to_db(named_ui_profiles_dict.values())
-    db_writer.remove_contextualized_termcodes_without_ui_profiles()
     write_used_value_sets_to_files(named_ui_profiles_dict.values(), result_dir / 'value-sets')
     write_used_criteria_sets_to_files(named_ui_profiles_dict.values(), result_dir / 'criteria-sets')
 

--- a/common/resources/sql/delete_statements.sql
+++ b/common/resources/sql/delete_statements.sql
@@ -1,12 +1,12 @@
-DELETE FROM public.criteria_set;
+--DELETE FROM public.criteria_set;
 DELETE FROM public.contextualized_termcode;
-DELETE FROM public.contextualized_termcode_to_criteria_set;
+--DELETE FROM public.contextualized_termcode_to_criteria_set;
 DELETE FROM public.ui_profile;
-DELETE FROM public.mapping;
+--DELETE FROM public.mapping;
 DELETE FROM public.context;
 DELETE FROM public.termcode;
-ALTER SEQUENCE public.criteria_set_id_seq RESTART WITH 1;
+--ALTER SEQUENCE public.criteria_set_id_seq RESTART WITH 1;
 ALTER SEQUENCE public.ui_profile_id_seq RESTART WITH 1;
-ALTER SEQUENCE public.mapping_id_seq RESTART WITH 1;
+--ALTER SEQUENCE public.mapping_id_seq RESTART WITH 1;
 ALTER SEQUENCE public.context_id_seq RESTART WITH 1;
 ALTER SEQUENCE public.termcode_id_seq RESTART WITH 1;

--- a/common/resources/sql/init.sql
+++ b/common/resources/sql/init.sql
@@ -26,51 +26,48 @@ CREATE TABLE IF NOT EXISTS context
 );
 
 
-CREATE TABLE IF NOT EXISTS mapping
-(
-    id      SERIAL PRIMARY KEY,
-    name    TEXT NOT NULL,
-    type    TEXT NOT NULL,
-    UNIQUE (name, type),
-    content JSON NOT NULL
-);
+--CREATE TABLE IF NOT EXISTS mapping
+--(
+--    id      SERIAL PRIMARY KEY,
+--    name    TEXT NOT NULL,
+--    type    TEXT NOT NULL,
+--    UNIQUE (name, type),
+--    content JSON NOT NULL
+--);
 
 CREATE TABLE IF NOT EXISTS contextualized_termcode
 (
     context_termcode_hash TEXT PRIMARY KEY,
     context_id            INTEGER NOT NULL,
     termcode_id           INTEGER NOT NULL,
-    mapping_id            INTEGER,
-    ui_profile_id         INTEGER,
+    ui_profile_id         INTEGER NOT NULL,
     CONSTRAINT CONTEXT_ID_FK FOREIGN KEY (context_id)
         REFERENCES CONTEXT (id) ON DELETE CASCADE,
     CONSTRAINT CONCEPT_ID_FK FOREIGN KEY (termcode_id)
         REFERENCES termcode (id) ON DELETE CASCADE,
-    CONSTRAINT mapping_id_fk FOREIGN KEY (mapping_id)
-        REFERENCES mapping (id),
     CONSTRAINT ui_profile_id_fk FOREIGN KEY (ui_profile_id)
         REFERENCES ui_profile (id),
     UNIQUE (context_id, termcode_id)
 );
 
-CREATE TABLE IF NOT EXISTS criteria_set
-(
-    id  SERIAL PRIMARY KEY,
-    url TEXT UNIQUE NOT NULL
-);
+--CREATE TABLE IF NOT EXISTS criteria_set
+--(
+--    id  SERIAL PRIMARY KEY,
+--    url TEXT UNIQUE NOT NULL
+--);
 
-CREATE TABLE IF NOT EXISTS contextualized_termcode_to_criteria_set
-(
-    context_termcode_hash       TEXT    NOT NULL,
-    criteria_set_id INTEGER NOT NULL,
-    UNIQUE (context_termcode_hash, criteria_set_id),
-    CONSTRAINT CRITERIA_SET_ID_FK FOREIGN KEY (criteria_set_id)
-        REFERENCES CRITERIA_SET (id) ON DELETE CASCADE,
-    CONSTRAINT CONTEXTUALIZED_TERMCODE_ID_FK FOREIGN KEY (context_termcode_hash)
-        REFERENCES CONTEXTUALIZED_TERMCODE (context_termcode_hash) ON DELETE CASCADE
-);
+--CREATE TABLE IF NOT EXISTS contextualized_termcode_to_criteria_set
+--(
+--    context_termcode_hash       TEXT    NOT NULL,
+--    criteria_set_id INTEGER NOT NULL,
+--    UNIQUE (context_termcode_hash, criteria_set_id),
+--    CONSTRAINT CRITERIA_SET_ID_FK FOREIGN KEY (criteria_set_id)
+--        REFERENCES CRITERIA_SET (id) ON DELETE CASCADE,
+--    CONSTRAINT CONTEXTUALIZED_TERMCODE_ID_FK FOREIGN KEY (context_termcode_hash)
+--        REFERENCES CONTEXTUALIZED_TERMCODE (context_termcode_hash) ON DELETE CASCADE
+--);
 
-CREATE INDEX idx_mapping_name_mapping ON mapping (name);
+--CREATE INDEX idx_mapping_name_mapping ON mapping (name);
 CREATE INDEX idx_contextualized_termcode_termcode_fk ON contextualized_termcode (termcode_id);
 
 COMMENT ON COLUMN contextualized_termcode.context_termcode_hash IS 'This value is hashed using UUID-V3 (MD5) from the concatenated string of (context.system, context.code, context.version, termcode.system, termcode.code, termcode.version), omitting null values for version and without any delimiters. The mandatory namespace UUID will be predefined and shared along all components. The conversion between chars and bytes for hashing is using UTF-8 encoding.';

--- a/common/util/sql/merging.py
+++ b/common/util/sql/merging.py
@@ -254,8 +254,8 @@ class SqlMerger:
 
                 # Import the ui_profile table and write back new foreign keys to import schema
                 query_copy_contextualized_termcodes = """
-                INSERT INTO public.contextualized_termcode (context_termcode_hash, context_id, termcode_id, mapping_id, ui_profile_id)
-                SELECT context_termcode_hash, context_id, termcode_id, mapping_id, ui_profile_id
+                INSERT INTO public.contextualized_termcode (context_termcode_hash, context_id, termcode_id, ui_profile_id)
+                SELECT context_termcode_hash, context_id, termcode_id, ui_profile_id
                 FROM {schema_name}.contextualized_termcode
                 ON CONFLICT DO NOTHING;
                 """.format(schema_name=schema_name)

--- a/tests/integration/integrity/database/sql_import_test.py
+++ b/tests/integration/integrity/database/sql_import_test.py
@@ -4,6 +4,7 @@ from psycopg2._psycopg import connection
 def test_ui_profile_data(database: connection):
     cursor = database.cursor()
 
+    # TODO: Remove this assertion since it is ensured by a database constraint
     # Ensure that all contextualized term code entries reference a UI profile
     cursor.execute("""
         SELECT tc.system AS system_url, COUNT(*) AS cnt FROM contextualized_termcode ct 


### PR DESCRIPTION
Cohort Selection Ontology:
  UI Profiles:
    - Remove unused tables, associated indices and constraints since they are no longer needed
    - Add NON NULL constraint on column `ui_profile` in table `contextualized_termcode`