### PR TITLE
Add codecov to the ci test pipeline

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -74,7 +74,12 @@ jobs:
       run: pip3 install pytest pytest-docker pytest-cov
 
     - name: Run integration tests
-      run: pytest test/integration -v --cov --project "fdpg-ontology"
+      run: pytest test/integration -v --cov --cov-branch --cov-report=xml --project "fdpg-ontology"
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload Docker logs
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Add OSSF Scorecard to fhir-ontology-generator.

Add badges for [OSSF Scordecard](https://github.com/marketplace/actions/ossf-scorecard-action), [codecov ](https://github.com/codecov/codecov-action)and requiered [python](https://gist.github.com/jhrcook/5238fb7a7782db8bcb10c8d531fe9d38) (3.9) version to the README on main branch