### PR TITLE
Add Termcode and Terminology to children, parents and related items:

### DIFF
--- a/cohort_selection_ontology/model/ui_data.py
+++ b/cohort_selection_ontology/model/ui_data.py
@@ -86,11 +86,15 @@ class Module:
 class RelationalTermcode:
     contextualized_termcode_hash: str
     display: str | dict
+    terminology: str
+    term_code: str
 
     def to_dict(self):
         return {
             "contextualized_termcode_hash": self.contextualized_termcode_hash,
-            "display": self.display
+            "display": self.display,
+            "terminology": self.terminology,
+            "term_code": self.term_code,
         }
 
 

--- a/elasticsearch/core/generators.py
+++ b/elasticsearch/core/generators.py
@@ -101,6 +101,8 @@ class ElasticSearchGenerator:
                 parent_context, parent_term_code, namespace_uuid_str=namespace_uuid_str
             ),
             display=self.__designation_resolver.resolve_term(parent_term_code),
+            terminology=system,
+            term_code=code
         )
 
         return parent_relational_termcode

--- a/projects/fdpg-ontology/input/elastic/ontology_index.json
+++ b/projects/fdpg-ontology/input/elastic/ontology_index.json
@@ -70,6 +70,14 @@
           "name": {
             "type": "text",
             "index": false
+          },
+          "terminology": {
+            "type": "text",
+            "index": false
+          },
+          "term_code": {
+            "type": "text",
+            "index": false
           }
         }
       },
@@ -123,6 +131,14 @@
           "name": {
             "type": "text",
             "index": false
+          },
+          "terminology": {
+            "type": "text",
+            "index": false
+          },
+          "term_code": {
+            "type": "text",
+            "index": false
           }
         }
       },
@@ -133,6 +149,14 @@
             "index": false
           },
           "name": {
+            "type": "text",
+            "index": false
+          },
+          "terminology": {
+            "type": "text",
+            "index": false
+          },
+          "term_code": {
             "type": "text",
             "index": false
           }

--- a/tests/integration/integrity/json/schemata/elastic_ontology_content_schema.json
+++ b/tests/integration/integrity/json/schemata/elastic_ontology_content_schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "mapping_cql_schema.json",
   "titel": "Mapping CQL JSON Schema",
-  "description": "Used for checking integrity of generated mapping_cql.json",
+  "description": "Used for checking integrity of generated elastic_search_ontology_files.json",
   "type": "object",
   "properties": {
     "name": {"type": "string"},
@@ -24,7 +24,9 @@
       "type": "object",
       "properties": {
         "contextualized_termcode_hash": {"type": "string"},
-        "display": { "$ref": "https://fdpg.de/elastic_display.json" }
+        "display": { "$ref": "https://fdpg.de/elastic_display.json" },
+        "termcode": {"type": "string"},
+        "terminology": {"type": "string"}
       }
     }
   }


### PR DESCRIPTION
Common:
  - add Termcode and Terminology to RelationalTermcode dataclass
  - adapt new structure in ontology_index.json for es Tests:
  - add new structure to json schema files