### PR TITLE
Rework release CI workflow

### DIFF
--- a/.github/actions/generate-ontology/action.yml
+++ b/.github/actions/generate-ontology/action.yml
@@ -5,45 +5,77 @@ description: 'Generates ontology files'
 inputs:
   project:
     required: false
-    default: "fdpg-ontology"
     description: 'Name of the project to generate the ontology files for. Defaults to "fdpg-ontology"'
-  steps_to_run:
+    default: ""
+  term-server-url:
+    required: true
+    description: 'URL of the FHIR terminology server to use'
+  term-server-cert:
     required: false
-    description: 'Optional non-empty list of steps of the ontology generation to run. If not supplied all steps 
-                  will be run. The steps to run should be supplied as a JSON array of greater than zero integers 
-                  matching the indices of the steps to run.
-                  
-                  Examples: "[1, 3, 5, 6]"; "[2]"; "[4, 3, 2]"'
+    description: '(Optional) certificate to authenticate with the terminology server'
+  term-server-key:
+    required: false
+    description: '(Optional) private key to authenticate with the terminology server'
 
 runs:
   using: "composite"
   steps:
-    - name: Set default
+    - name: Set locale
       shell: bash
-      run: echo "GENERATOR_STEPS=--all" >> $GITHUB_ENV
-    - name: Parsing generator steps to run
-      shell: bash
-      if: ${{ inputs.steps_to_run != '' }}
       run: |
-        echo "GENERATOR_STEPS=--step ${{ join(fromJSON(inputs.steps_to_run), ' --step ') }}" >> $GITHUB_ENV
-        echo "Using generator scripts with arguments $GENERATOR_STEPS"
+        sudo apt-get update
+        sudo apt-get install tzdata locales -y
+        sudo locale-gen de_DE.UTF-8
+        sudo localectl set-locale LANG="de_DE.UTF-8"
+        export LANG="de_DE.UTF-8"
+        sudo update-locale
+        locale -a
+        locale
+        locale -c -k LC_NUMERIC
+        localectl status
+
+    - name: Setup python 3 environment
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+        cache: 'pip'
+
+    - name: Install required python modules
+      shell: bash
+      run: pip3 install -r requirements.txt
 
     - name: Save secret to file
-      shell: bash
       id: certificates
+      env:
+        SERVER_CERTIFICATE: ${{ inputs.term-server-cert }}
+        PRIVATE_KEY: ${{ inputs.term-server-key }}
+      shell: bash
       run: |
         echo "$PRIVATE_KEY" > private-key.pem
         echo "$SERVER_CERTIFICATE" > certificate.pem
         echo privateKey=$(readlink -f private-key.pem) >> "$GITHUB_OUTPUT"
         echo certificate=$(readlink -f certificate.pem) >> "$GITHUB_OUTPUT"
-      env:
-        SERVER_CERTIFICATE: ${{ secrets.FDPGPLUS_ONTO_SERVER_CERT }}
-        PRIVATE_KEY: ${{ secrets.FDPGPLUS_ONTO_SERVER_KEY }}
 
     - name: Run ontology generation
-      shell: bash
       env:
-        ONTOLOGY_SERVER_ADDRESS: ${{ secrets.FDPGPLUS_ONTO_SERVER_URL }}
+        ONTOLOGY_SERVER_ADDRESS: ${{ inputs.term-server-url }}
         SERVER_CERTIFICATE: ${{ steps.certificates.outputs.certificate }}
         PRIVATE_KEY: ${{ steps.certificates.outputs.privateKey }}
-      run: ./generate_full_ontology.sh --project ${{ inputs.project }} ${{ GENERATOR_STEPS }}
+      shell: bash
+      run: ./generate_full_ontology.sh --project ${{ inputs.project }} --all
+
+    - name: Upload Ontology
+      uses: actions/upload-artifact@v4
+      with:
+        name: packaged ontology
+        path: |
+          projects/${{ inputs.project }}/output/merged_ontology/elastic.zip
+          projects/${{ inputs.project }}/output/merged_ontology/backend.zip
+          projects/${{ inputs.project }}/output/merged_ontology/mapping.zip
+
+    - name: Project Output - Ontology
+      uses: actions/upload-artifact@v4
+      with:
+        name: project output
+        path: |
+          projects/${{ inputs.project }}/output/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,78 +10,135 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: "requires-terminology-server"
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-  release:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      - name: Generate ontology files
+        uses: ./.github/actions/generate-ontology
+        with:
+          project: "fdpg-ontology"
+          term-server-url: ${{ secrets.FDPGPLUS_ONTO_SERVER_URL }}
+          term-server-cert: ${{ secrets.FDPGPLUS_ONTO_SERVER_CERT }}
+          term-server-key: ${{ secrets.FDPGPLUS_ONTO_SERVER_KEY }}
+
+  generate_availability:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v4
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-    - name: Set locale
-      run: |
-        sudo apt-get update
-        sudo apt-get install tzdata locales -y
-        sudo locale-gen de_DE.UTF-8
-        sudo localectl set-locale LANG="de_DE.UTF-8"
-        export LANG="de_DE.UTF-8"
-        sudo update-locale
-        locale -a
-        locale
-        locale -c -k LC_NUMERIC
-        localectl status
+      - name: Generate_Availability
+        uses: ./.github/actions/availability
+        with:
+          tag: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
 
-    - name: Generate Availability
-      uses: ./.github/actions/availability
+  run_integration_tests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Download Ontology
+        uses: actions/download-artifact@v4
+        with:
+          name: packaged ontology
+          path: projects/fdpg-ontology/output/merged_ontology
+
+      - name: Install required python modules
+        run: pip3 install -r requirements.txt
+
+      - name: Install testing pytest
+        run: pip3 install pytest pytest-docker pytest-cov
+
+      - name: Save secret to file
+        id: certificates
+        run: |
+          echo "$PRIVATE_KEY" > private-key.pem
+          echo "$SERVER_CERTIFICATE" > certificate.pem
+          echo privateKey=$(readlink -f private-key.pem) >> "$GITHUB_OUTPUT"
+          echo certificate=$(readlink -f certificate.pem) >> "$GITHUB_OUTPUT"
+        env:
+          SERVER_CERTIFICATE: ${{ secrets.FDPGPLUS_ONTO_SERVER_CERT }}
+          PRIVATE_KEY: ${{ secrets.FDPGPLUS_ONTO_SERVER_KEY }}
+
+      - name: Run integration tests
+        env:
+          ONTOLOGY_SERVER_ADDRESS: ${{ secrets.FDPGPLUS_ONTO_SERVER_URL }}
+          SERVER_CERTIFICATE: ${{ steps.certificates.outputs.certificate }}
+          PRIVATE_KEY: ${{ steps.certificates.outputs.privateKey }}
+        run: pytest tests/integration -v --cov --cov-branch --cov-report=xml --project "fdpg-ontology" --ignore=tests/integration/integrity/json
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload Docker logs
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: docker_logs_integration_testing
+          path: tests/integration/backend/docker_logs
+
+  run_json_integrity_tests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install required python modules
+        run: pip3 install -r requirements.txt
+
+      - name: Download Ontology
+        uses: actions/download-artifact@v4
+        with:
+          name: project output
+          path: projects/fdpg-ontology/output/
+
+      - name: Install testing pytest
+        run: pip3 install pytest pytest-docker pytest-cov pytest-xdist
+
+      - name: Run integration tests
+        env:
+          ONTOLOGY_SERVER_ADDRESS: ${{ secrets.FDPGPLUS_ONTO_SERVER_URL }}
+          SERVER_CERTIFICATE: ${{ steps.certificates.outputs.certificate }}
+          PRIVATE_KEY: ${{ steps.certificates.outputs.privateKey }}
+        run: pytest tests/integration/integrity/json -v -n 10 --cov --cov-branch --cov-report=xml --project "fdpg-ontology"
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  release:
+    needs: [build, generate_availability, run_integration_tests, run_json_integrity_tests]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download Ontology
+      uses: actions/download-artifact@v4
       with:
-        tag: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+        name: project output
+        path: projects/fdpg-ontology/output/
 
-    - name: Setup python 3 environment
-      uses: actions/setup-python@v5
+    - name: Download Availability
+      uses: actions/download-artifact@v4
       with:
-        python-version: '3.13'
-        cache: 'pip'
-
-    - name: Install required python modules
-      run: pip3 install -r requirements.txt
-
-    - name: Save secret to file
-      id: certificates
-      run: |
-        echo "$PRIVATE_KEY" > private-key.pem
-        echo "$SERVER_CERTIFICATE" > certificate.pem
-        echo privateKey=$(readlink -f private-key.pem) >> "$GITHUB_OUTPUT"
-        echo certificate=$(readlink -f certificate.pem) >> "$GITHUB_OUTPUT"
-      env:
-        SERVER_CERTIFICATE: ${{ secrets.FDPGPLUS_ONTO_SERVER_CERT }}
-        PRIVATE_KEY: ${{ secrets.FDPGPLUS_ONTO_SERVER_KEY }}
+        name: availability-zip
+        path: projects/fdpg-ontology/output/availability/availability.zip
 
     - name: Collect DSE structure definition snapshots
       shell: bash
       run: zip -j dse_structures.zip projects/fdpg-ontology/input/data_selection_extraction/snapshots/mii/*
 
-    - name: Run ontology generation
-      env:
-        ONTOLOGY_SERVER_ADDRESS: ${{ secrets.FDPGPLUS_ONTO_SERVER_URL }}
-        SERVER_CERTIFICATE: ${{ steps.certificates.outputs.certificate }}
-        PRIVATE_KEY: ${{ steps.certificates.outputs.privateKey }}
-      run: ./generate_full_ontology.sh --project "fdpg-ontology" --all
-
-    - name: Run integration tests
-      env:
-        ONTOLOGY_SERVER_ADDRESS: ${{ secrets.FDPGPLUS_ONTO_SERVER_URL }}
-        SERVER_CERTIFICATE: ${{ steps.certificates.outputs.certificate }}
-        PRIVATE_KEY: ${{ steps.certificates.outputs.privateKey }}
-      run: pytest tests/integration -v --cov --project "fdpg-ontology"
-
-    - name: Upload Docker logs
-      uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: docker_logs
-        path: tests/integration/backend/docker_logs
-
-    - name: Release
+    - name: Release Draft
       uses: softprops/action-gh-release@v2
       with:
         draft: true
@@ -90,5 +147,5 @@ jobs:
           projects/fdpg-ontology/output/merged_ontology/elastic.zip
           projects/fdpg-ontology/output/merged_ontology/backend.zip
           projects/fdpg-ontology/output/merged_ontology/mapping.zip
-          availability/availability.zip
+          projects/fdpg-ontology/output/availability/availability.zip
           dse_structures.zip

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -12,68 +12,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
+    concurrency:
+      group: "requires-terminology-server"
+      cancel-in-progress: false
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set locale
-        run: |
-          sudo apt-get update
-          sudo apt-get install tzdata locales -y
-          sudo locale-gen de_DE.UTF-8
-          sudo localectl set-locale LANG="de_DE.UTF-8"
-          export LANG="de_DE.UTF-8"
-          sudo update-locale
-          locale -a
-          locale
-          locale -c -k LC_NUMERIC
-          localectl status
-
-      - name: Setup python 3 environment
-        uses: actions/setup-python@v5
+      - name: Generate ontology files
+        uses: ./.github/actions/generate-ontology
         with:
-          python-version: '3.13'
-          cache: 'pip'
-
-      - name: Install required python modules
-        run: pip3 install -r requirements.txt
-
-      - name: Save secret to file
-        id: certificates
-        run: |
-          echo "$PRIVATE_KEY" > private-key.pem
-          echo "$SERVER_CERTIFICATE" > certificate.pem
-          echo privateKey=$(readlink -f private-key.pem) >> "$GITHUB_OUTPUT"
-          echo certificate=$(readlink -f certificate.pem) >> "$GITHUB_OUTPUT"
-        env:
-          SERVER_CERTIFICATE: ${{ secrets.FDPGPLUS_ONTO_SERVER_CERT }}
-          PRIVATE_KEY: ${{ secrets.FDPGPLUS_ONTO_SERVER_KEY }}
-
-      - name: Run ontology generation
-        env:
-          ONTOLOGY_SERVER_ADDRESS: ${{ secrets.FDPGPLUS_ONTO_SERVER_URL }}
-          SERVER_CERTIFICATE: ${{ steps.certificates.outputs.certificate }}
-          PRIVATE_KEY: ${{ steps.certificates.outputs.privateKey }}
-        run: ./generate_full_ontology.sh --project "fdpg-ontology" --all
-
-      - name: Upload Ontology
-        uses: actions/upload-artifact@v4
-        with:
-          name: packaged ontology
-          path: |
-            projects/fdpg-ontology/output/merged_ontology/elastic.zip
-            projects/fdpg-ontology/output/merged_ontology/backend.zip
-            projects/fdpg-ontology/output/merged_ontology/mapping.zip
-
-      - name: Project Output - Ontology
-        uses: actions/upload-artifact@v4
-        with:
-          name: project output
-          path: |
-            projects/fdpg-ontology/output/
+          project: "fdpg-ontology"
+          term-server-url: ${{ secrets.FDPGPLUS_ONTO_SERVER_URL }}
+          term-server-cert: ${{ secrets.FDPGPLUS_ONTO_SERVER_CERT }}
+          term-server-key: ${{ secrets.FDPGPLUS_ONTO_SERVER_KEY }}
 
   generate_availability:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI/CD:
  - Rework release CI workflow by splitting it into multiple jobs
  - Add build jobs to separate concurrency group to prevent overload of terminology server

Closes: #374 