### PR TITLE
Fix intermediate nodes missing in profile tree and add ordering

### DIFF
--- a/common/util/http/exceptions.py
+++ b/common/util/http/exceptions.py
@@ -17,7 +17,11 @@ class ClientError(Exception):
         super().__init__(
             f"Request failed with status code {status_code}"
             + (f". Reason: {reason}" if reason is not None else "")
-            + (f"\nAdditional:\n{text}" if text is not None else "")
+            + (
+                f"\nAdditional:\n{text.decode(encoding='utf-8')}"
+                if text is not None
+                else ""
+            )
         )
         self.status_code = status_code
 
@@ -32,9 +36,13 @@ class ServerError(Exception):
         text: Optional[str] = None,
     ):
         super().__init__(
-            f"Request failed with status code {status_code}" + f". Reason: {reason}"
-            if reason is not None
-            else "" + f"\nAdditional:\n{text}" if text is not None else ""
+            f"Request failed with status code {status_code}"
+            + (f". Reason: {reason}" if reason is not None else "")
+            + (
+                f"\nAdditional:\n{text.decode(encoding='utf-8')}"
+                if text is not None
+                else ""
+            )
         )
         self.status_code = status_code
 

--- a/data_selection_extraction/model/detail.py
+++ b/data_selection_extraction/model/detail.py
@@ -10,7 +10,6 @@ from cohort_selection_ontology.model.ui_data import (
     BulkTranslationDisplayElement,
 )
 from common.util.fhir.enums import FhirDataType, FhirSearchType, FhirComplexDataType
-from common.util.http.backend.client import FeasibilityBackendClient
 
 
 class Filter(BaseModel):

--- a/data_selection_extraction/scripts/generate_dse_files.py
+++ b/data_selection_extraction/scripts/generate_dse_files.py
@@ -214,7 +214,8 @@ def generate_cs_tree_map(
                     for parent in parents:
                         treemap.entries[parent].children.append(node)
     except Exception as e:
-        _logger.error(e, exc_info=e)
+        _logger.error(e)
+        _logger.debug("Traceback:\n", exc_info=e)
 
     return treemap
 


### PR DESCRIPTION
Data Selection Extraction:
  - Fix nodes of sliced element-containing element slices missing in profile details fields tree
  - Add ordering of field tree nodes based on underlying element path and order of slices in StructureDefinition resource

Common:
  - Improve logging of HTTP request failures

Closes: #393 