### PR TITLE
Switch over to FHIR W5 mapping based subject resolution for element availability

### DIFF
--- a/tests/unit/availability/test_element_availability.py
+++ b/tests/unit/availability/test_element_availability.py
@@ -10,6 +10,7 @@ from fhir.resources.R4B.elementdefinition import (
     ElementDefinition,
     ElementDefinitionBinding,
     ElementDefinitionSlicingDiscriminator,
+    ElementDefinitionMapping,
 )
 from fhir.resources.R4B.expression import Expression
 from fhir.resources.R4B.elementdefinition import ElementDefinitionType
@@ -1046,6 +1047,11 @@ def test__generate_stratifiers_for_elem_def(
                                 ElementDefinitionType(
                                     code="Reference",
                                 ),
+                            ],
+                            mapping=[
+                                ElementDefinitionMapping(
+                                    identity="w5", map="FiveWs.subject"
+                                )
                             ],
                         ),
                         ElementDefinition(


### PR DESCRIPTION
Availability:
  Element Availability:
    - Switch over to FHIR W5 mapping based subject resolution to avoid hard-coded element names

General:
  - Fix reference field resolution by accounting for reference elements that allow any FHIR resource type