### PR TITLE
Add ref-based targeting to GitHub FHIR package manager and fix unnecessary inflation

### DIFF
--- a/projects/fdpg-ontology/config.yml
+++ b/projects/fdpg-ontology/config.yml
@@ -4,7 +4,7 @@ fhir-packages:
     params:
       org: "medizininformatik-initiative"
       repo: "fhir-package-store"
-      branch: "main"
+      ref: "main"
       path: "package-tarballs"
 http:
   timeout: "PT30S"

--- a/tests/integration/backend/search_responses.json
+++ b/tests/integration/backend/search_responses.json
@@ -823,7 +823,7 @@
                                 },
                                 {
                                     "language": "en-US",
-                                    "value": "\"Section\" examination - approved doctor"
+                                    "value": "Section examination - approved doctor"
                                 }
                             ]
                         },

--- a/tests/unit/availability/config.yml
+++ b/tests/unit/availability/config.yml
@@ -4,5 +4,5 @@ fhir-packages:
     params:
       org: "medizininformatik-initiative"
       repo: "fhir-package-store"
-      branch: "main"
+      ref: "c7e7b8dfc78d9e41c69e3d60c9d95b6a55347af3"
       path: "package-tarballs"


### PR DESCRIPTION
Common:
  FHIR Package Management:
    - Replace 'branch' parameter with 'ref' parameter of GitHub package manager to specify either a ref, tag, or branch of the repostory to download packages from
    - Fix unnecessary inflation of packages by keeping track of already inflated packages