### PR TITLE
Include admission identifier of MII CDS Encounter profile

### DIFF
--- a/projects/fdpg-ontology/input/data_selection_extraction/field_config.json
+++ b/projects/fdpg-ontology/input/data_selection_extraction/field_config.json
@@ -255,7 +255,16 @@
             "note": "is auto preselected for each resource in background"
           }
         ]
-      }
+      },
+      "exclude": [
+        {
+          "id": "Encounter.identifier",
+          "match": {
+            "target": "id",
+            "pattern": "Encounter.identifier"
+          }
+        }
+      ]
     },
     "http://hl7.org/fhir/StructureDefinition/Medication": {
       "recommend": {
@@ -701,6 +710,16 @@
           }
         ]
       }
+    },
+    "https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung": {
+      "include": [
+        {
+          "match": {
+            "target": "id",
+            "pattern": "Encounter.identifier:Aufnahmenummer$"
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
FDPG Ontology:
  Data Selection Extraction:
    - Include admission identifier of MII CDS Encounter profile in field config

Closes: #438 