### PR TITLE
Fix DSE time filter mapping

### DIFF
--- a/projects/fdpg-ontology/input/data_selection_extraction/search_filter_mapping.json
+++ b/projects/fdpg-ontology/input/data_selection_extraction/search_filter_mapping.json
@@ -7,7 +7,7 @@
     "Bundle": "timestamp",
     "CarePlan": "date",
     "Composition": "date",
-    "Condition": "onset-date",
+    "Condition": "recorded-date",
     "Consent": "date",
     "Coverage": null,
     "Device": null,


### PR DESCRIPTION
Data Selection Extraction:
  - Change search parameter used as time filter for Condition resource type from 'onset-date' to 'recorded-date'

Closes: #473 