### PR TITLE
Add index definition for profile details and refactor elastic release artifact

### DIFF
--- a/cohort_selection_ontology/model/ui_data.py
+++ b/cohort_selection_ontology/model/ui_data.py
@@ -6,7 +6,7 @@ import random as rd
 import uuid
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 def del_none(dictionary):
@@ -104,7 +104,7 @@ class RelationalTermcode(BaseModel):
 
 class Translation(BaseModel):
     language: str
-    value: Optional[str]
+    value: Optional[str] = Field(default=None)
 
 
 class BulkTranslation(BaseModel):

--- a/data_selection_extraction/core/generators/profile_detail.py
+++ b/data_selection_extraction/core/generators/profile_detail.py
@@ -13,6 +13,7 @@ from cohort_selection_ontology.model.ui_data import (
     TranslationDisplayElement,
     BulkTranslationDisplayElement,
     Translation,
+    BulkTranslation,
 )
 from common.model.fhir.structure_definition import (
     StructureDefinitionSnapshot,
@@ -452,15 +453,6 @@ class ProfileDetailGenerator:
                 return element
         return None
 
-    @staticmethod
-    def get_value_for_lang_code(data: ElementDefinition, lang_code: str) -> None | str:
-        if data is None:
-            return None
-        for ext in data.extension:
-            if any(e.url == "lang" and e.valueCode == lang_code for e in ext.extension):
-                return next(e.valueString for e in ext.extension if e.url == "content")
-        return None
-
     def resource_type_to_date_param(self, resource_type: str) -> Optional[str]:
         if resource_type in self.__search_filter_mapping:
             # NOTE: Having an explicit null value in the mapping indicates that there is no applicable search parameter
@@ -714,7 +706,7 @@ class ProfileDetailGenerator:
             )
 
     def generate_detail_for_profile(
-        self, profile: Mapping[str, any], profile_tree: Optional[ProfileTreeNode] = None
+        self, profile: Mapping[str, Any], profile_tree: list[ProfileTreeNode]
     ) -> Optional[ProfileDetail]:
         profile_url = profile.get("url")
         self.__logger.info(f"Generating profile detail [url='{profile_url}']")
@@ -752,13 +744,13 @@ class ProfileDetailGenerator:
                     translations=[
                         Translation(
                             language="de-DE",
-                            value=self.get_value_for_lang_code(
+                            value=get_value_for_lang_code(
                                 struct_def.title__ext, "de-DE"
                             ),
                         ),
                         Translation(
                             language="en-US",
-                            value=self.get_value_for_lang_code(
+                            value=get_value_for_lang_code(
                                 struct_def.title__ext, "en-US"
                             ),
                         ),
@@ -927,8 +919,10 @@ class ProfileDetailGenerator:
                                             "structureDefinition"
                                         )
                                     ),
-                                    fields=self.__get_fields_for_profile(
-                                        url, profile_tree
+                                    fields=self.__get_field_names_for_profile(
+                                        self.__all_profiles.get(url).get(
+                                            "structureDefinition"
+                                        )
                                     ),
                                 )
                                 for url in referenced_mii_profiles
@@ -960,15 +954,11 @@ class ProfileDetailGenerator:
                     translations=[
                         Translation(
                             language="de-DE",
-                            value=self.get_value_for_lang_code(
-                                element.short__ext, "de-DE"
-                            ),
+                            value=get_value_for_lang_code(element.short__ext, "de-DE"),
                         ),
                         Translation(
                             language="en-US",
-                            value=self.get_value_for_lang_code(
-                                element.short__ext, "en-US"
-                            ),
+                            value=get_value_for_lang_code(element.short__ext, "en-US"),
                         ),
                     ],
                 )
@@ -977,13 +967,13 @@ class ProfileDetailGenerator:
                     translations=[
                         Translation(
                             language="de-DE",
-                            value=self.get_value_for_lang_code(
+                            value=get_value_for_lang_code(
                                 element.definition__ext, "de-DE"
                             ),
                         ),
                         Translation(
                             language="en-US",
-                            value=self.get_value_for_lang_code(
+                            value=get_value_for_lang_code(
                                 element.definition__ext, "en-US"
                             ),
                         ),
@@ -1002,7 +992,7 @@ class ProfileDetailGenerator:
 
     @staticmethod
     def __find_profile_in_tree(
-        profile_url: str, profile_tree: ProfileTreeNode
+        profile_url: str, profile_tree: list[ProfileTreeNode]
     ) -> Optional[ProfileTreeNode]:
         """
         Searches for a profile in the given profile tree by its URL
@@ -1010,19 +1000,20 @@ class ProfileDetailGenerator:
         :param profile_tree: Profile tree to search in
         :return: Profile tree entry representing the profile or `None` if no entry matches
         """
-        if profile_tree.url == profile_url:
-            return profile_tree
-        else:
-            results = [
-                ProfileDetailGenerator.__find_profile_in_tree(profile_url, tree)
-                for tree in profile_tree.children
-            ]
-            results = list(filter(lambda t: t is not None, results))
-            return results[0] if len(results) > 0 else None
+        for tree_node in profile_tree:
+            if tree_node.url == profile_url:
+                return tree_node
+            else:
+                node = ProfileDetailGenerator.__find_profile_in_tree(
+                    profile_url, tree_node.children
+                )
+                if node:
+                    return node
+        return None
 
     @staticmethod
     def __is_profile_selectable(
-        profile_url: str, profile_tree: ProfileTreeNode
+        profile_url: str, profile_tree: list[ProfileTreeNode]
     ) -> bool:
         """
         Searches the profile tree to determine whether a profile (identified by the provided URL) is selectable. Returns
@@ -1036,26 +1027,39 @@ class ProfileDetailGenerator:
         )
         return profile.selectable if profile is not None else False
 
-    @staticmethod
-    def __get_fields_for_profile(
-        profile_url: str, profile_tree: ProfileTreeNode
+    def __get_field_names_for_profile(
+        self, struct_def: StructureDefinitionSnapshot
     ) -> BulkTranslationDisplayElement:
-        """
-        Searches for the profile with the given profile URL in the given profile tree and returns its supported fields
-        :param profile_url: URL of the profile to return the supported fields of
-        :param profile_tree: Profile tree to search
-        :return: `BulkTranslationDisplayElement` instances representing the supported fields names
-        """
-        profile = ProfileDetailGenerator.__find_profile_in_tree(
-            profile_url, profile_tree
+        names_original = []
+        names_en = []
+        names_de = []
+
+        for element in struct_def.snapshot.element:
+            element: ElementDefinition
+            if not self.is_field_included(element, struct_def):
+                continue
+
+            elem_name_de = get_value_for_lang_code(element.short__ext, "de-DE")
+            elem_name_en = get_value_for_lang_code(element.short__ext, "en-US")
+
+            names_original.append(self.get_name_from_id(element.id))
+
+            names_de.append(elem_name_de)
+            names_en.append(elem_name_en)
+
+        return BulkTranslationDisplayElement(
+            original=names_original,
+            translations=[
+                BulkTranslation(language="de-DE", value=names_de),
+                BulkTranslation(language="en-US", value=names_en),
+            ],
         )
-        return profile.fields
 
     def generate_profile_details_for_profiles_in_scope(
         self,
         scope: str,
         cond: Optional[Callable[[Mapping[str, Any]], bool]] = None,
-        profile_tree: ProfileTreeNode = None,
+        profile_tree: list[ProfileTreeNode] | None = None,
     ) -> List[ProfileDetail]:
         """
         Generate profile details for all profiles within the given scope
@@ -1066,6 +1070,7 @@ class ProfileDetailGenerator:
                             profile based on whether it is selectable
         :return: List of profile details for the given scope
         """
+        profile_tree = profile_tree if profile_tree else []
         self.__logger.info(
             f"Generating profile details for profiles in scope '{scope}'"
         )

--- a/data_selection_extraction/core/generators/profile_tree.py
+++ b/data_selection_extraction/core/generators/profile_tree.py
@@ -6,13 +6,12 @@ import shutil
 from os.path import basename
 from pathlib import Path
 
+import cachetools
 import pydantic
 from fhir.resources.R4B.elementdefinition import ElementDefinition
 from fhir.resources.R4B.structuredefinition import StructureDefinition
 
 from cohort_selection_ontology.model.ui_data import (
-    BulkTranslationDisplayElement,
-    BulkTranslation,
     TranslationDisplayElement,
     Translation,
 )
@@ -23,7 +22,7 @@ from common.model.fhir.structure_definition import (
 )
 from common.model.fhir.structure_definition import StructureDefinitionSnapshot
 from common.util.fhir.enums import FhirPrimitiveDataType, FhirComplexDataType
-from common.util.log.functions import get_class_logger
+from common.util.log.functions import get_logger
 
 from enum import Enum
 from typing import Mapping, Optional, Any, List
@@ -37,6 +36,8 @@ from data_selection_extraction.config.profile_detail import FieldsConfig
 from data_selection_extraction.model.profile_tree import ProfileTreeNode
 from data_selection_extraction.util.fhir.profile import is_profile_selectable
 
+_logger = get_logger(__file__)
+
 
 _EXT_ELEM_PATTERN = re.compile(
     r".*extension(:(?P<slice_name>[a-zA-Z0-9\/\\\-_\[\]\@]+))?"
@@ -49,16 +50,53 @@ class SnapshotPackageScope(str, Enum):
 
 
 def get_value_for_lang_code(data: ElementDefinition, lang_code: str) -> Optional[str]:
-    if data is None:
-        return None
-    for ext in data.extension:
-        if any(e.url == "lang" and e.valueCode == lang_code for e in ext.extension):
-            return next(e.valueString for e in ext.extension if e.url == "content")
+    if data and (extensions := data.extension):
+        for transl_ext in filter(
+            lambda ext: ext.url
+            == "http://hl7.org/fhir/StructureDefinition/translation",
+            extensions,
+        ):
+            if any(
+                e.url == "lang" and e.valueCode == lang_code
+                for e in transl_ext.extension
+            ):
+                return next(
+                    (e.valueString for e in transl_ext.extension if e.url == "content"),
+                    None,
+                )
     return None
 
 
+def _condense_profile_tree(
+    profile_tree: ProfileTreeNode, distance_from_root: int = 0
+) -> ProfileTreeNode:
+    """
+    Condenses a given profile tree by removing intermediate nodes that are not selectable and do not have multiple
+    children
+    :param profile_tree: `ProfileTreeNode` instance representing the root of a profile tree to condense
+    :param distance_from_root: distance from root node to the current `ProfileTreeNode`. For internal use only.
+                               Providing a value is discouraged
+    :return: Condensed profile tree
+    """
+    if (
+        len(profile_tree.children) > 1
+        or profile_tree.selectable
+        or profile_tree.leaf
+        or distance_from_root == 1
+    ):
+        profile_tree.children = [
+            _condense_profile_tree(c, distance_from_root + 1)
+            for c in profile_tree.children
+        ]
+        return profile_tree
+    else:
+        # Exactly one child element should exist at this point since the node has neither more than one child nor is
+        # a leaf node
+        _logger.info(f"Removing node {profile_tree.name!r} from the tree")
+        return _condense_profile_tree(profile_tree.children[0], distance_from_root + 1)
+
+
 class ProfileTreeGenerator:
-    __logger = get_class_logger("ProfileTreeGenerator")
 
     def __init__(
         self,
@@ -73,7 +111,6 @@ class ProfileTreeGenerator:
         project: Project,
     ):
         """
-
         :param packages_dir: dependencies folder
         :param snapshots_dir: snapshots folder
         :param excluded_dirs: folders to exclude from the packages_dir
@@ -98,6 +135,24 @@ class ProfileTreeGenerator:
         self.fields_config = fields_config
         self.profiles_to_process = profiles_to_process
         self.__project = project
+        self.__package_manager = project.package_manager
+
+    @cachetools.cachedmethod(
+        cache=lambda self: self.__is_included_cache,
+        key=lambda _, ed, pr: pr.url + "#" + ed.id,
+    )
+    def is_field_included(
+        self, elem_def: ElementDefinition, profile: IndexedStructureDefinition
+    ) -> bool:
+        if profile.get_aggregated_max_cardinality(elem_def.id) == 0:
+            return False
+        is_included = self.fields_config.is_included(
+            elem_def, profile, self.__project.package_manager
+        )
+        if is_included is None:
+            return not self.filter_element(elem_def, profile)
+        else:
+            return is_included
 
     def __get_profiles(
         self, scope: Optional[str] = None
@@ -139,9 +194,7 @@ class ProfileTreeGenerator:
             getattr(element, "subject", None) is not None
             or getattr(element, "patient", None) is not None
         ):
-            self.__logger.info(
-                f"Excluding: {element['id']} as having references to patients"
-            )
+            _logger.info(f"Excluding: {element['id']} as having references to patients")
             return True
 
         # attributes_true_level_two = ["mustSupport", "isModifier"]
@@ -150,20 +203,18 @@ class ProfileTreeGenerator:
             t.code in FhirPrimitiveDataType
             for t in get_types_supported_by_element(element)
         ):
-            self.__logger.debug(
-                f"Excluding: {element.id} as primitively-typed on level > 2"
-            )
+            _logger.debug(f"Excluding: {element.id} as primitively-typed on level > 2")
             return True
 
         # if any(
         #    element.id.endswith(field) or f"{field}." in element.id
         #    for field in self.fields_to_exclude
         # ):
-        #    self.__logger.debug(f"Excluding: {element.id} as excluded field")
+        #    _logger.debug(f"Excluding: {element.id} as excluded field")
         #    return True
 
         # if any(f"{field}" in element.id for field in self.field_trees_to_exclude):
-        #    self.__logger.debug(f"Excluding: {element.id} as part of field tree")
+        #    _logger.debug(f"Excluding: {element.id} as part of field tree")
         #    return True
 
         parent_elem = profile.get_element_by_id(element_id.rsplit(".", maxsplit=1)[0])
@@ -188,7 +239,7 @@ class ProfileTreeGenerator:
             element.base.path.split(".")[0] in {"Resource", "DomainResource"}
             and element.mustSupport is not None
         ):
-            self.__logger.debug(
+            _logger.debug(
                 f"Excluding: {element.id} as base is Resource or DomainResource and not mustSupport"
             )
             return True
@@ -224,83 +275,60 @@ class ProfileTreeGenerator:
         else:
             return is_included
 
-    def get_field_names_for_profile(
+    def get_fields_for_profile(
         self, struct_def: StructureDefinitionSnapshot
-    ) -> BulkTranslationDisplayElement:
-        names_original = []
-        names_en = []
-        names_de = []
+    ) -> list[tuple[TranslationDisplayElement, TranslationDisplayElement | None]]:
+        fields = []
 
         for element in struct_def.snapshot.element:
             element: ElementDefinition
-            if self.filter_element(element, struct_def):
+            if not self.is_field_included(element, struct_def):
                 continue
 
-            elem_name_de = get_value_for_lang_code(element.short__ext, "de-DE")
-            elem_name_en = get_value_for_lang_code(element.short__ext, "en-US")
-
-            names_original.append(self.get_name_from_id(element.id))
-
-            # if elem_name_de == "":
-            #    continue
-
-            names_de.append(elem_name_de)
-            names_en.append(elem_name_en)
-
-        return BulkTranslationDisplayElement(
-            original=names_original,
-            translations=[
-                BulkTranslation(language="de-DE", value=names_de),
-                BulkTranslation(language="en-US", value=names_en),
-            ],
-        )
-
-    def build_profile_path(self, path, profile, profiles) -> List[ProfileTreeNode]:
-        profile_struct: StructureDefinitionSnapshot = profile["structureDefinition"]
-        parent_profile_url = profile_struct.baseDefinition
-
-        try:
-            profile_field_names = self.get_field_names_for_profile(profile_struct)
-        except KeyError as err:
-            raise err
-
-        path.insert(
-            0,
-            ProfileTreeNode(
-                id=str(uuid.uuid4()),
-                name=profile["name"],
-                display=TranslationDisplayElement(
-                    original=(
-                        profile_struct.title
-                        if profile_struct.title is not None
-                        else profile_struct.name
+            fields.append(
+                (
+                    TranslationDisplayElement(
+                        original=self.get_name_from_id(element.id),
+                        translations=[
+                            Translation(
+                                language="de-DE",
+                                value=get_value_for_lang_code(
+                                    element.short__ext, "de-DE"
+                                ),
+                            ),
+                            Translation(
+                                language="en-US",
+                                value=get_value_for_lang_code(
+                                    element.short__ext, "en-US"
+                                ),
+                            ),
+                        ],
                     ),
-                    translations=[
-                        Translation(
-                            language="de-DE",
-                            value=get_value_for_lang_code(
-                                profile_struct.title__ext, "de-DE"
-                            ),
-                        ),
-                        Translation(
-                            language="en-US",
-                            value=get_value_for_lang_code(
-                                profile_struct.title__ext, "en-US"
-                            ),
-                        ),
-                    ],
-                ),
-                fields=profile_field_names,
-                module=profile["module"],
-                url=profile["url"],
-            ),
-        )
+                    (
+                        TranslationDisplayElement(
+                            original=element.definition,
+                            translations=[
+                                Translation(
+                                    language="de-DE",
+                                    value=get_value_for_lang_code(
+                                        element.definition__ext, "de-DE"
+                                    ),
+                                ),
+                                Translation(
+                                    language="en-US",
+                                    value=get_value_for_lang_code(
+                                        element.definition__ext, "en-US"
+                                    ),
+                                ),
+                            ],
+                        )
+                        if element.definition
+                        else None
+                    ),
+                )
+            )
 
-        if parent_profile_url in profiles:
-            parent_profile = profiles[parent_profile_url]
-            self.build_profile_path(path, parent_profile, profiles)
-
-        return path
+        return fields
 
     def get_profile_in_node(self, node: ProfileTreeNode, name: str):
         children = node.children
@@ -309,25 +337,6 @@ class ProfileTreeGenerator:
             if child.name == name:
                 return index
         return -1
-
-    def insert_path_to_tree(self, tree: ProfileTreeNode, path: List[ProfileTreeNode]):
-        cur_node = tree
-        for index in range(0, len(path)):
-            profile = path[index]
-
-            profile_child_index = self.get_profile_in_node(cur_node, profile.name)
-
-            snapshot = self.__all_profiles.get(profile.url, {}).get(
-                "structureDefinition"
-            )
-            profile.selectable = is_profile_selectable(snapshot, self.__all_profiles)
-
-            if profile_child_index == -1:
-                cur_node.children.append(profile)
-                profile_child_index = self.get_profile_in_node(cur_node, profile.name)
-                cur_node = cur_node.children[profile_child_index]
-            else:
-                cur_node = cur_node.children[profile_child_index]
 
     def module_name_to_display(self, profile_name):
         parts = profile_name.split("-")
@@ -348,7 +357,7 @@ class ProfileTreeGenerator:
         # exclude_dirs = set(os.path.abspath(os.path.join(self.packages_dir, d)) for d in self.exclude_dirs)
         # print(exclude_dirs)
         if not any(self.packages_dir.iterdir()):
-            self.__logger.warning(
+            _logger.warning(
                 f"Package directory @ '{self.packages_dir}' is empty => No snapshots can be copied"
             )
 
@@ -388,19 +397,17 @@ class ProfileTreeGenerator:
                                 os.path.join(self.snapshots_dir, snapshot_scope),
                                 os.path.basename(file_path),
                             )
-                            self.__logger.info(
+                            _logger.info(
                                 f"Copying snapshot file for further processing: {file_path} -> "
                                 f"{destination}"
                             )
                             shutil.copy(file_path, destination)
                 except UnicodeDecodeError:
-                    self.__logger.warning(
+                    _logger.warning(
                         f"File {file_path} is not a text file or cannot be read as text."
                     )
                 except Exception as exc:
-                    self.__logger.error(
-                        f"Failed to copy file '{file_path}'", exc_info=exc
-                    )
+                    _logger.error(f"Failed to copy file '{file_path}'", exc_info=exc)
 
     def get_profile_snapshots(self):
         for root, dirs, files in os.walk(self.snapshots_dir):
@@ -413,7 +420,9 @@ class ProfileTreeGenerator:
                 try:
                     with open(file_path, mode="r", encoding="utf-8") as f:
                         try:
-                            content = construct_model(idx_struct_def_discriminator, **json.load(f))
+                            content = construct_model(
+                                idx_struct_def_discriminator, **json.load(f)
+                            )
                         except pydantic.ValidationError as e:
                             error_list = ""
                             for err in e.errors():
@@ -421,7 +430,7 @@ class ProfileTreeGenerator:
                                 error_list = (
                                     f"\n\t\t\t{ '.'.join(map(str, loc))}: {err['msg']}"
                                 )
-                            self.__logger.error(
+                            _logger.error(
                                 f"Failed to parse snapshot {basename(file_path)} at {error_list}"
                             )
 
@@ -454,36 +463,28 @@ class ProfileTreeGenerator:
                                 "url": content.url,
                             }
 
-                            self.__logger.info(
+                            _logger.info(
                                 f"Adding profile snapshot to tree: {file_path}"
                             )
 
                         else:
-                            self.__logger.debug(
+                            _logger.debug(
                                 f"Profile did not match criteria for inclusion: {file_path}"
                             )
 
                 except UnicodeDecodeError:
-                    self.__logger.warning(
+                    _logger.warning(
                         f"File {file_path} is not a text file or cannot be read as text => Skipping"
                     )
                 except Exception as exc:
-                    self.__logger.warning(
+                    _logger.warning(
                         f"File {file_path} could not be processed. Reason: {exc}",
                         exc_info=exc,
                     )
 
         self.__all_profiles = self.__get_profiles()
 
-    @staticmethod
-    def custom_sort(item, order):
-        name = item.name
-        if name in order:
-            return 0, order.index(name)
-        else:
-            return 1, name
-
-    def get_suitable_mii_profiles(self) -> Mapping[str, Mapping[str, any]]:
+    def get_suitable_mii_profiles(self) -> Mapping[str, Mapping[str, Any]]:
         """
         Returns only those profiles which are snapshots that apply to FHIR resource types excluding Extension and are
         part of the Medical Informatics Initiative (MII)
@@ -500,86 +501,170 @@ class ProfileTreeGenerator:
                 profiles[url] = profile
         return profiles
 
-    def generate_profiles_tree(self, condense=True):
+    def __insert_into_tree(
+        self, node: ProfileTreeNode, deps: set[str], tree: list[ProfileTreeNode]
+    ):
+        """
+        Inserts a node into the given profile (sub)tree using its dependency chain as a path in the tree. Tree nodes
+        have to be inserted in order of their number of dependencies
+
+        :param node: ``ProfileTreeNode`` object to insert into the tree
+        :param deps: Set of canonical URLs making up the dependency chain, i.e. the structure definitions this profile
+                     represented by node is (transitively) derived from
+        :param tree: List of ``ProfileTreeNode`` objects representing the tree
+        """
+        if deps:
+            for tree_node in tree:
+                if tree_node.url in deps:
+                    deps.remove(tree_node.url)
+                    if len(deps) == 0:
+                        tree_node.children.append(node)
+                    else:
+                        self.__insert_into_tree(node, deps, tree_node.children)
+                    return
+        tree.append(node)
+
+    def __build_tree(self, nodes: list[ProfileTreeNode]) -> list[ProfileTreeNode]:
+        """
+        Constructs the profile tree from the list of all nodes it should contain. ``ProfileTreeNode.children`` will be
+        filled as the tree is constructed
+
+        :param nodes: List of ``ProfileTreeNode`` objects that will be part of the tree
+        :return: List of ``ProfileTreeNode`` objects representing the first level of the tree (e.g. the immediate
+                 subtrees with nodes as roots whos profiles do not have any dependency in the tree)
+        """
+        canonicals = {node.url for node in nodes}
+        nodes_and_deps = []
+        for node in nodes:
+            struct_def = self.__package_manager.find_struct_def(node.url)
+            deps = {
+                dep.url
+                for dep in self.__package_manager.dependencies_of(
+                    struct_def, latest_only=False
+                )
+            }
+            deps_in_tree = deps.intersection(canonicals)
+            entry = (
+                node,
+                deps_in_tree,
+            )
+            nodes_and_deps.append(entry)
+        tree = []
+        for node, deps in sorted(nodes_and_deps, key=lambda t: len(t[1])):
+            self.__insert_into_tree(node, deps, tree)
+        return tree
+
+    def generate_profiles_tree(self, condense=True) -> list[ProfileTreeNode]:
         """
         Generates a profile tree from the profiles in scope
         :param condense: If set to `True` the tree will be condensed according to
                 `ProfileTreeGenerator::__condense_profile_tree`
         :return: Generated profile tree
         """
-        self.__logger.info("Generating profile tree")
-
-        # tree = {"name": "Root", "module": "no-module", "url": "no-url", "children": [], "selectable": False}
-        tree = ProfileTreeNode(id="root", name="Root")
-
+        _logger.info("Generating profile tree nodes")
+        nodes = []
         for profile in self.get_suitable_mii_profiles().values():
             # The Patient resource is selected by default due to its special status and thus there is no need to have
             # profiles constraining this resource type in the profile tree
             struct_def = profile.get("structureDefinition", {})
             if struct_def.type == "Patient":
-                self.__logger.info(
+                _logger.info(
                     f"Profile '{struct_def.id}' will not be present in the profile tree as the "
                     f"Patient resource is selected by default => Skipping"
                 )
                 continue
 
-            self.__logger.info(f"Processing profile {profile.get('name')}")
+            _logger.debug(f"Processing profile {profile.get('name')!r}")
             try:
-                path = self.build_profile_path(
-                    [], profile, self.__get_profiles(SnapshotPackageScope.MII)
-                )
-                module = profile["module"]
-                path.insert(
-                    0,
+                profile_struct: StructureDefinitionSnapshot = profile[
+                    "structureDefinition"
+                ]
+
+                try:
+                    profile_field_names = self.get_fields_for_profile(profile_struct)
+                except KeyError as err:
+                    raise err
+
+                profile_module = profile["module"]
+                nodes.append(
                     ProfileTreeNode(
                         id=str(uuid.uuid4()),
-                        name=module,
+                        name=profile["name"],
                         display=TranslationDisplayElement(
-                            original=self.module_translation["de-DE"].get(
-                                module, module
+                            original=(
+                                profile_struct.title
+                                if profile_struct.title is not None
+                                else profile_struct.name
                             ),
                             translations=[
                                 Translation(
                                     language="de-DE",
+                                    value=get_value_for_lang_code(
+                                        profile_struct.title__ext, "de-DE"
+                                    ),
+                                ),
+                                Translation(
+                                    language="en-US",
+                                    value=get_value_for_lang_code(
+                                        profile_struct.title__ext, "en-US"
+                                    ),
+                                ),
+                            ],
+                        ),
+                        description=TranslationDisplayElement(
+                            original=str(profile_struct.description),
+                            translations=[
+                                Translation(
+                                    language="de-DE",
+                                    value=get_value_for_lang_code(
+                                        profile_struct.description__ext, "de-DE"
+                                    ),
+                                ),
+                                Translation(
+                                    language="en-US",
+                                    value=get_value_for_lang_code(
+                                        profile_struct.description__ext, "en-US"
+                                    ),
+                                ),
+                            ],
+                        ),
+                        fields=profile_field_names,
+                        module=TranslationDisplayElement(
+                            original=profile_module,
+                            translations=[
+                                Translation(
+                                    language="de-DE",
                                     value=self.module_translation["de-DE"].get(
-                                        module, module
+                                        profile_module, profile_module
                                     ),
                                 ),
                                 Translation(
                                     language="en-US",
                                     value=self.module_translation["en-US"].get(
-                                        module, module
+                                        profile_module, profile_module
                                     ),
                                 ),
                             ],
                         ),
-                        url=module,
-                        module=module,
-                        selectable=False,
-                        fields=BulkTranslationDisplayElement(
-                            original=[],
-                            translations=[
-                                BulkTranslation(language="de-DE", value=[]),
-                                BulkTranslation(language="en-US", value=[]),
-                            ],
+                        url=profile["url"],
+                        resource_type=profile_struct.type,
+                        selectable=is_profile_selectable(
+                            profile_struct, self.__all_profiles
                         ),
-                    ),
+                    )
                 )
-                self.insert_path_to_tree(tree, path)
             except Exception as exc:
-                self.__logger.error(profile.get("name"))
+                _logger.error(profile.get("name"))
                 raise exc
 
+        _logger.info("Building profile tree")
+        tree = self.__build_tree(nodes)
+
         if condense:
-            self.__logger.info("Condensing profile tree")
-            tree = self.__condense_profile_tree(tree)
+            _logger.info("Condensing profile tree")
+            tree = [_condense_profile_tree(tree_node) for tree_node in tree]
 
-        sorted_tree = tree
-        sorted_tree.children = sorted(
-            tree.children, key=lambda item: self.custom_sort(item, self.module_order)
-        )
-
-        return sorted_tree
+        return tree
 
     @staticmethod
     def determine_snapshot_scope_for_package(
@@ -598,36 +683,3 @@ class ProfileTreeGenerator:
                 return SnapshotPackageScope.MII
             else:
                 return SnapshotPackageScope.DEFAULT
-
-    @classmethod
-    def __condense_profile_tree(
-        cls, profile_tree: ProfileTreeNode, distance_from_root: int = 0
-    ) -> ProfileTreeNode:
-        """
-        Condenses a given profile tree by removing intermediate nodes that are not selectable and do not have multiple
-        children
-        :param profile_tree: `ProfileTreeNode` instance representing the root of a profile tree to condense
-        :param distance_from_root: distance from root node to the current `ProfileTreeNode`. For internal use only. Providing a value is discouraged
-        :return: Condensed profile tree
-        """
-        if (
-            len(profile_tree.children) > 1
-            or profile_tree.selectable
-            or profile_tree.leaf
-            or distance_from_root == 1
-        ):
-            tree = profile_tree.model_copy()
-        else:
-            # Exactly one child element should exist at this point since the node has neither more than one child nor is
-            # a leaf node
-            child_names = [f"'{n.name}'" for n in profile_tree.children]
-            cls.__logger.info(
-                f"Removing node [id='{profile_tree.id}', name='{profile_tree.name}'] from tree "
-                f"[children={child_names}]"
-            )
-            tree = profile_tree.children[0].model_copy()
-        tree.children = [
-            ProfileTreeGenerator.__condense_profile_tree(n, distance_from_root + 1)
-            for n in tree.children
-        ]
-        return tree

--- a/data_selection_extraction/model/profile_tree.py
+++ b/data_selection_extraction/model/profile_tree.py
@@ -1,12 +1,10 @@
-from typing import Mapping, List
+from typing import List
 from uuid import uuid4
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, computed_field, Field, TypeAdapter
 from typing_extensions import Optional, Self
 
 from cohort_selection_ontology.model.ui_data import (
-    BulkTranslationDisplayElement,
-    BulkTranslation,
     TranslationDisplayElement,
 )
 
@@ -15,13 +13,20 @@ class ProfileTreeNode(BaseModel):
     id: str = str(uuid4())
     name: str
     display: Optional[TranslationDisplayElement] = None
+    description: Optional[TranslationDisplayElement] = None
     url: Optional[str] = None
-    module: Optional[str] = None
+    module: Optional[TranslationDisplayElement] = None
     selectable: bool = False
-    fields: BulkTranslationDisplayElement = BulkTranslationDisplayElement()
-    children: List[Self] = []
+    fields: list[tuple[TranslationDisplayElement, TranslationDisplayElement | None]] = Field(
+        default_factory=list
+    )
+    children: List["ProfileTreeNode"] = []
+    resource_type: Optional[str] = Field(default=None)
 
     @computed_field
     @property
     def leaf(self) -> bool:
         return len(self.children) == 0
+
+
+ProfileTreeTA = TypeAdapter(list[ProfileTreeNode])

--- a/data_selection_extraction/scripts/generate_dse_files.py
+++ b/data_selection_extraction/scripts/generate_dse_files.py
@@ -2,7 +2,6 @@ import argparse
 import collections
 import os
 import json
-from pathlib import Path
 
 from typing import Union, Literal, Mapping, List, Any, Optional
 from urllib.parse import urlparse
@@ -28,6 +27,7 @@ from cohort_selection_ontology.model.tree_map import TreeMap, TermEntryNode
 from cohort_selection_ontology.model.ui_data import TermCode
 from common.util.log.functions import get_logger
 from data_selection_extraction.model.detail import ProfileDetailListTA
+from data_selection_extraction.model.profile_tree import ProfileTreeTA
 
 _logger = get_logger(__file__)
 
@@ -375,11 +375,12 @@ if __name__ == "__main__":
     if args.copy_snapshots:
         tree_generator.copy_profile_snapshots()
 
+    _logger.info("Generating profile tree")
     tree_generator.get_profile_snapshots()
     profile_tree = tree_generator.generate_profiles_tree()
 
-    with open(dse_output_dir / "profile_tree.json", mode="w", encoding="utf-8") as f:
-        json.dump(profile_tree, f, ensure_ascii=False, cls=JSONFhirOntoEncoder)
+    with open(dse_output_dir / "profile_tree.json", mode="wb") as f:
+        f.write(ProfileTreeTA.dump_json(profile_tree, exclude_none=True))
 
     with open(
         dse_input_dir / "mapping-type-code.json", mode="r", encoding="utf-8"

--- a/elasticsearch/core/generators.py
+++ b/elasticsearch/core/generators.py
@@ -2,21 +2,116 @@ import os
 import json
 import shutil
 import uuid
-import zipfile
-from typing import Mapping
-from zipfile import ZipFile
+from pathlib import Path
+from typing import Mapping, Any, Callable, TypeVar
 import re
 
 from cohort_selection_ontology.model.ui_data import RelationalTermcode
 from common.util.codec.json import JSONFhirOntoEncoder
+from data_selection_extraction.model.profile_tree import ProfileTreeNode, ProfileTreeTA
 from elasticsearch.core.resolvers.designation import TerminologyDesignationResolver
 
-from common.util.log.functions import get_class_logger
+from common.util.log.functions import get_logger
 from common.util.project import Project
+from elasticsearch.model.profile_index import ProfileIndexDocument
+
+_logger = get_logger(__file__)
+
+
+########################################################################################################################
+# Serialization functions
+########################################################################################################################
+
+
+def _ontology_doc_ser(_, doc: Any) -> tuple[bytes, bytes]:
+    obj_hash = doc["hash"]
+    del doc["hash"]
+    action_and_metadata_d = (
+        f'{{"index": {{"_index": "ontology", "_id": "{obj_hash}"}}}}\n'.encode("utf-8")
+    )
+    doc_b = (json.dumps(doc, cls=JSONFhirOntoEncoder) + "\n").encode("utf-8")
+    return action_and_metadata_d, doc_b
+
+
+def _codeable_concept_doc_ser(_, doc: Any) -> tuple[bytes, bytes]:
+    obj_hash = doc["hash"]
+    del doc["hash"]
+    action_and_metadata_d = (
+        f'{{"index": {{"_index": "codeable_concept", "_id": "{obj_hash}"}}}}\n'.encode(
+            "utf-8"
+        )
+    )
+    doc_b = (json.dumps(doc, cls=JSONFhirOntoEncoder) + "\n").encode("utf-8")
+    return action_and_metadata_d, doc_b
+
+
+def _profile_doc_ser(idx: int, doc: ProfileIndexDocument) -> tuple[bytes, bytes]:
+    action_and_metadata_b = (
+        f'{{"index": {{"_index": "profile", "_id": "{idx}"}}}}\n'.encode("utf-8")
+    )
+    doc_bytes_b = (doc.model_dump_json() + "\n").encode(encoding="utf-8")
+    return action_and_metadata_b, doc_bytes_b
+
+
+########################################################################################################################
+
+
+T = TypeVar("T")
+
+
+def _write_es_documents(
+    dst: Path,
+    file_name_prefix: str,
+    index_name: str,
+    documents: list[T],
+    serializer: Callable[[int, T], tuple[bytes, bytes]],
+    max_doc_cnt: int = 10_000,
+    max_file_size_mb: int = 10,
+):
+    """
+    Serializes list of objects as Elasticsearch index documents and writes them as bulk import NDJSON files to the disk.
+    A new files is created if either ``max_doc_count`` or ``max_file_size_mb`` is exceeded
+
+    :param dst: Path to the destination directory
+    :param file_name_prefix: Name prefix of the NDJSON files
+    :param index_name: Name of the Elasticsearch index the documents should be uploaded to
+    :param documents: List of objects that are part of the bulk import
+    :param serializer: Callable taking in the index of the object in the list and the object itself. It should return a
+                       tuple where the first entry is the action JSON object and the second the serialized data to index
+    :param max_doc_cnt: Maximum number of documents to be part of a single NDJSON file
+    :param max_file_size_mb: Maximum NDJSON file size (in MB)
+    """
+    if not documents:
+        _logger.warning(f"No documents to write for index {repr(index_name)}")
+        return
+    max_file_size_bytes = max_file_size_mb * 1024 * 1024
+    current_file_subindex = 0
+    current_file_size = 0
+    current_doc_cnt = 0
+
+    fd = (dst / f"{file_name_prefix}_{current_file_subindex}.ndjson").open(mode="wb")
+    try:
+        for idx, doc in enumerate(documents):
+            action_and_metadata_b, doc_b = serializer(idx, doc)
+            num_new_bytes = len(action_and_metadata_b) + len(doc_b)
+            current_doc_cnt += 2
+            if (
+                current_file_size + num_new_bytes
+            ) >= max_file_size_bytes or current_doc_cnt >= max_doc_cnt:
+                fd.close()
+                current_file_subindex += 1
+                current_file_size = num_new_bytes
+                current_doc_cnt = 2
+                fd = (dst / f"{file_name_prefix}_{current_file_subindex}.ndjson").open(
+                    mode="wb"
+                )
+            fd.write(action_and_metadata_b)
+            fd.write(doc_b)
+    finally:
+        fd.close()
 
 
 class ElasticSearchGenerator:
-    __logger = get_class_logger("ElasticSearchGenerator")
 
     def __init__(self, project: Project):
         self.__project = project
@@ -128,7 +223,7 @@ class ElasticSearchGenerator:
             if not self.__designation_resolver.has_designations_for(
                 ui_tree.get("system")
             ):
-                self.__logger.warning(
+                _logger.warning(
                     f"No designations are loaded for code system '{ui_tree.get('system')}' => No translations will be "
                     f"available"
                 )
@@ -198,7 +293,7 @@ class ElasticSearchGenerator:
 
     def __convert_value_set(self, value_set, termcode_to_valueset, namespace_uuid_str):
         if len(value_set.get("expansion", {}).get("contains", [])) == 0:
-            self.__logger.warning(
+            _logger.warning(
                 f"Value set [url={value_set.get('url', '<missing>')}] is not expanded or its "
                 f"expansion is empty => Skipping"
             )
@@ -230,45 +325,8 @@ class ElasticSearchGenerator:
                     value_set["url"]
                 )
 
-    def __write_es_import_to_file(
-        self,
-        current_file_index,
-        current_file_name,
-        json_flat,
-        index_name,
-        max_filesize_mb,
-        filename_prefix,
-        extension,
-    ):
-        current_file_subindex = 1
-        current_file_size = 0
-
-        elastic_dir = self.__project.output.mkdirs("merged_ontology", "elastic")
-        with open(current_file_name, mode="a", encoding="UTF-8") as current_file:
-            for obj in json_flat:
-                obj_hash = obj["hash"]
-                del obj["hash"]
-                current_line = (
-                    f'{{"index": {{"_index": "{index_name}", "_id": "{obj_hash}"}}}}\n'
-                )
-                current_file.write(current_line)
-                current_file_size += len(current_line)
-                current_line = json.dumps(obj, cls=JSONFhirOntoEncoder) + "\n"
-                current_file.write(current_line)
-                current_file_size += len(current_line)
-
-                if current_file_size > max_filesize_mb * 1024 * 1024:
-                    current_file_subindex += 1
-                    current_file_name = elastic_dir / (
-                        f"{filename_prefix}_{index_name}_{current_file_index}_"
-                        + f"{current_file_subindex}{extension}"
-                    )
-                    current_file_size = 0
-                    current_file.close()
-                    current_file = open(current_file_name, mode="w", encoding="UTF-8")
-
     @staticmethod
-    def __write_es_to_file(
+    def __update_es_files_with_availability(
         es_availability_inserts, max_filesize_mb, filename_prefix, extension, write_dir
     ):
         current_file_subindex = 1
@@ -279,7 +337,7 @@ class ElasticSearchGenerator:
         current_file_name = os.path.join(
             write_dir, f"{filename_prefix}_{current_file_subindex}{extension}"
         )
-        ElasticSearchGenerator.__logger.debug(f"Writing to file {current_file_name}")
+        _logger.debug(f"Writing to file {current_file_name}")
         with open(current_file_name, mode="w+", encoding="UTF-8") as current_file:
 
             for insert in es_availability_inserts:
@@ -297,33 +355,7 @@ class ElasticSearchGenerator:
                     current_file_size = 0
                     current_file.close()
                     current_file = open(current_file_name, mode="w", encoding="UTF-8")
-                    ElasticSearchGenerator.__logger.debug(
-                        f"Writing to file {current_file_name}"
-                    )
-
-    @staticmethod
-    def __zip_elastic_files(
-        output_file, work_dir, filename_prefix, extension, include_additional_files
-    ):
-        with ZipFile(
-            output_file, mode="w", compression=zipfile.ZIP_DEFLATED
-        ) as elastic_zip:
-            # Add the new files to the zipfile
-            for root, dirs, files in os.walk(work_dir):
-                for file in files:
-                    if file.startswith(filename_prefix) and file.endswith(extension):
-                        os.chdir(root)
-                        elastic_zip.write(filename=file, arcname=f"{file}")
-                        os.remove(file)
-            # Add files from additional folders if any
-            if include_additional_files:
-                for root, dirs, files in os.walk(include_additional_files):
-                    for file in files:
-                        file_path = os.path.join(root, file)
-                        elastic_zip.write(
-                            file_path,
-                            os.path.relpath(file_path, include_additional_files),
-                        )
+                    _logger.debug(f"Writing to file {current_file_name}")
 
     def __load_termcode_info(
         self, tree_file_name, namespace_uuid_str
@@ -341,9 +373,7 @@ class ElasticSearchGenerator:
         ) as f:
             term_code_info_list = json.load(f)
 
-            self.__logger.debug(
-                f"Loaded termcode info map from file '{filename_prefix}'"
-            )
+            _logger.debug(f"Loaded termcode info map from file '{filename_prefix}'")
             for term_code_info in term_code_info_list:
                 term_code_hash = self.__get_contextualized_termcode_hash(
                     term_code_info["context"],
@@ -354,7 +384,7 @@ class ElasticSearchGenerator:
 
         return term_code_info_map
 
-    def __get_hashed_tree(self) -> Mapping[str, any]:
+    def __get_hashed_tree(self) -> Mapping[str, Any]:
         directory = self.__project.input.elastic
         es_onto_tree = {}
 
@@ -447,12 +477,39 @@ class ElasticSearchGenerator:
             )
         return count
 
+    def __generate_documents_from_profile_tree_node(
+        self,
+        node: ProfileTreeNode,
+        parent: ProfileIndexDocument | None = None,
+    ) -> list[ProfileIndexDocument]:
+        doc = ProfileIndexDocument.from_profile_tree_node(node)
+        doc.parents = [parent.to_ref()] if parent else []
+        return [
+            doc,
+            *(
+                desc_doc
+                for child in node.children
+                for desc_doc in self.__generate_documents_from_profile_tree_node(
+                    child, doc
+                )
+            ),
+        ]
+
+    def generate_profile_tree_files(
+        self, profile_tree: list[ProfileTreeNode]
+    ) -> list[ProfileIndexDocument]:
+        # Get module-level nodes
+        documents = []
+        for tree_node in profile_tree:
+            documents.extend(
+                self.__generate_documents_from_profile_tree_node(tree_node, None)
+            )
+        return documents
+
     def generate_elasticsearch_files(
         self,
         generate_availability,
         namespace_uuid_str="00000000-0000-0000-0000-000000000000",
-        index_name="ontology",
-        filename_prefix="onto_es_",
         max_filesize_mb=10,
         update_translation_supplements=False,
     ):
@@ -460,12 +517,11 @@ class ElasticSearchGenerator:
         translations_dir = self.__project.output.translation.mkdirs("supplements")
         availability_output_dir = self.__project.output.availability
 
-        extension = ".json"
         ui_tree_dir = generated_ontology_dir / "ui-trees"
         current_file_index = 0
 
         elastic_dir = generated_ontology_dir / "elastic"
-        self.__logger.debug(f"Cleaning up output directory @ {elastic_dir}")
+        _logger.debug(f"Cleaning up output directory @ {elastic_dir}")
         if elastic_dir.exists():
             shutil.rmtree(elastic_dir)
         os.makedirs(elastic_dir, exist_ok=True)
@@ -484,11 +540,11 @@ class ElasticSearchGenerator:
         )
 
         if generate_availability:
-            self.__logger.info("Generating availability")
+            _logger.info("Generating availability")
             es_availability_inserts = []
 
             avail_hash_tree = self.__get_hashed_tree()
-            self.__logger.debug("Updating availability on hash tree")
+            _logger.debug("Updating availability on hash tree")
             self.__update_availability_on_hash_tree(avail_hash_tree, namespace_uuid_str)
 
             for key, value in avail_hash_tree.items():
@@ -507,24 +563,20 @@ class ElasticSearchGenerator:
                 es_availability_inserts.append(insert_hash)
                 es_availability_inserts.append(insert_availability)
 
-            self.__write_es_to_file(
+            self.__update_es_files_with_availability(
                 es_availability_inserts,
                 max_filesize_mb,
                 "es_availability_update",
-                extension,
+                ".ndjson",
                 availability_output_dir,
             )
 
             return
 
-        self.__logger.info("Generating Elasticsearch term code index documents")
+        _logger.info("Generating Elasticsearch term code index documents")
         for filename in os.listdir(ui_tree_dir):
-            if filename.endswith(extension):
-                self.__logger.info(f"Processing {filename}")
-                current_file = (
-                    elastic_dir
-                    / f"{filename_prefix}_{index_name}_{current_file_index}{extension}"
-                )
+            if filename.endswith(".json"):
+                _logger.info(f"Processing {filename}")
 
                 with open(ui_tree_dir / filename, mode="r", encoding="UTF-8") as f:
                     json_tree = json.load(f)
@@ -542,43 +594,52 @@ class ElasticSearchGenerator:
                     namespace_uuid_str,
                 )
 
-                self.__write_es_import_to_file(
-                    current_file_index,
-                    current_file,
+                _write_es_documents(
+                    self.__project.output.mkdirs("merged_ontology", "elastic"),
+                    f"onto_es__ontology_{current_file_index}",
+                    "ontology",
                     json_flat,
-                    index_name,
-                    max_filesize_mb,
-                    filename_prefix,
-                    extension,
+                    _ontology_doc_ser,
                 )
 
                 current_file_index = current_file_index + 1
 
-        self.__logger.info("Generating Elasticsearch value set index documents")
-        index_name = "codeable_concept"
+        _logger.info("Generating Elasticsearch value set index documents")
         termcode_to_valueset = {}
 
-        current_file = (
-            elastic_dir
-            / f"{filename_prefix}_{index_name}_{current_file_index}{extension}"
-        )
-
         for filename in os.listdir(value_set_dir):
-            if filename.endswith(extension):
+            if filename.endswith(".json"):
+                _logger.info(f"Processing value set file {filename}")
                 with open(value_set_dir / filename, mode="r", encoding="UTF-8") as f:
                     value_set = json.load(f)
-                    self.__convert_value_set(
-                        value_set, termcode_to_valueset, namespace_uuid_str
-                    )
+                self.__convert_value_set(
+                    value_set, termcode_to_valueset, namespace_uuid_str
+                )
 
         json_flat = list(termcode_to_valueset.values())
 
-        self.__write_es_import_to_file(
-            current_file_index,
-            current_file,
+        _write_es_documents(
+            self.__project.output.mkdirs("merged_ontology", "elastic"),
+            "onto_es__codeable_concept",
+            "codeable_concept",
             json_flat,
-            index_name,
-            max_filesize_mb,
-            filename_prefix,
-            extension,
+            _codeable_concept_doc_ser,
+        )
+
+        _logger.info("Generating Elasticsearch profile index documents")
+
+        dse_output_dir = self.__project.output.dse
+        with (dse_output_dir / "profile_tree.json").open(
+            mode="r", encoding="utf-8"
+        ) as fd:
+            profile_tree = ProfileTreeTA.validate_json(fd.read())
+
+        documents = self.generate_profile_tree_files(profile_tree)
+
+        _write_es_documents(
+            self.__project.output.mkdirs("merged_ontology", "elastic"),
+            "onto_es__profile",
+            "profile",
+            documents,
+            _profile_doc_ser,
         )

--- a/elasticsearch/core/resolvers/designation.py
+++ b/elasticsearch/core/resolvers/designation.py
@@ -213,12 +213,12 @@ class TerminologyDesignationResolver:
                 match resource["resourceType"]:
                     case "Parameters":
                         for language in languages:
-                            code = list(
+                            code = next(
                                 filter(
                                     lambda p: p.get("name") == "code",
                                     resource.get("parameter", []),
                                 )
-                            )[0].get("valueCode")
+                            ).get("valueCode")
                             designation = extract_designation(resource, language)
                             if designation:
                                 if code not in code_system_concepts:
@@ -226,10 +226,6 @@ class TerminologyDesignationResolver:
                                 designations = code_system_concepts[code]
                                 if language not in designations:
                                     designations[language] = designation
-                            else:
-                                self.__logger.debug(
-                                    f"Failed to extract designation for language '{language}' [parameter='{json.dumps(resource)}']"
-                                )
                     case "OperationOutcome":
                         failure_cnt += 1
                         self.__logger.debug(f"Operation failed. Details:\n{resource}")

--- a/elasticsearch/model/profile_index.py
+++ b/elasticsearch/model/profile_index.py
@@ -1,0 +1,128 @@
+import json
+from typing import Dict
+
+from pydantic import BaseModel, Field, ConfigDict
+from importlib.resources import files
+
+import cohort_selection_ontology.model.ui_data
+from data_selection_extraction.model.profile_tree import ProfileTreeNode
+
+_RESOURCE_TYPE_LOCALIZATIONS = json.loads(
+    files("elasticsearch.model.resources")
+    .joinpath("resource_type_localizations.json")
+    .read_text(encoding="utf-8")
+)
+
+
+# TODO: Apply this new translation data model throughout the entire repository
+class TranslationDisplayElement(BaseModel):
+    original: str
+    localization: Dict[str, str] = Field(default_factory=dict)
+
+    def update_translations(self, **kwargs: tuple[str, str | None]):
+        """
+        Updates the associated value for each provided lang code. If a tuples value is ``None`` then no update is done
+        """
+        for lang, value in kwargs:
+            if value:
+                self.localization[lang] = value
+
+    @classmethod
+    def from_ui_model(
+        cls, obj: cohort_selection_ontology.model.ui_data.TranslationDisplayElement
+    ) -> "TranslationDisplayElement":
+        return TranslationDisplayElement(
+            original=obj.original,
+            localization={t.language: t.value for t in obj.translations if t.value},
+        )
+
+    @classmethod
+    def from_ui_bulk_model(
+        cls, obj: cohort_selection_ontology.model.ui_data.BulkTranslationDisplayElement
+    ) -> list["TranslationDisplayElement"]:
+        result = []
+        for v in obj.original:
+            result.append(TranslationDisplayElement(original=v))
+        for bulk_trans in obj.translations:
+            lang = bulk_trans.language
+            for idx, v in enumerate(bulk_trans.value):
+                if v:
+                    elem = result[idx]
+                    elem.localization[lang] = v
+        return result
+
+
+class ProfileIndexDocumentField(BaseModel):
+    display: TranslationDisplayElement
+    description: TranslationDisplayElement | None
+
+
+class ProfileIndexDocumentRef(BaseModel):
+    display: TranslationDisplayElement
+    url: str
+    selectable: bool
+
+
+class ProfileIndexDocument(BaseModel):
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+    name: str
+    display: TranslationDisplayElement
+    url: str
+    module: TranslationDisplayElement
+    selectable: bool = Field(default=True)
+    resource_type: TranslationDisplayElement = Field(alias="resourceType")
+    categories: list[TranslationDisplayElement] = Field(default_factory=list)
+    description: list[TranslationDisplayElement] = Field(default_factory=list)
+    availability: int = Field(default=0)
+    fields: list[ProfileIndexDocumentField] = Field(default_factory=list)
+    parents: list[ProfileIndexDocumentRef] = Field(default_factory=list)
+    children: list[ProfileIndexDocumentRef] = Field(default_factory=list)
+
+    def to_ref(self) -> ProfileIndexDocumentRef:
+        return ProfileIndexDocumentRef(
+            display=self.display.model_copy(deep=True),
+            url=self.url,
+            selectable=self.selectable,
+        )
+
+    @classmethod
+    def from_profile_tree_node(cls, node: ProfileTreeNode) -> "ProfileIndexDocument":
+        resource_type = TranslationDisplayElement(original=node.resource_type)
+        if resource_type_localization := _RESOURCE_TYPE_LOCALIZATIONS.get(
+            node.resource_type
+        ):
+            resource_type.localization = resource_type_localization.copy()
+        return ProfileIndexDocument(
+            name=node.name,
+            display=TranslationDisplayElement.from_ui_model(node.display),
+            url=node.url,
+            module=TranslationDisplayElement.from_ui_model(node.module),
+            selectable=node.selectable,
+            resource_type=resource_type,
+            description=(
+                [TranslationDisplayElement.from_ui_model(node.description)]
+                if node.description
+                else []
+            ),
+            availability=0,
+            fields=[
+                ProfileIndexDocumentField(
+                    display=TranslationDisplayElement.from_ui_model(field[0]),
+                    description=(
+                        TranslationDisplayElement.from_ui_model(field[1])
+                        if field[1]
+                        else None
+                    ),
+                )
+                for field in node.fields
+            ],
+            children=[
+                ProfileIndexDocumentRef(
+                    display=TranslationDisplayElement.from_ui_model(child.display),
+                    url=child.url,
+                    selectable=child.selectable,
+                )
+                for child in node.children
+            ],
+        )

--- a/elasticsearch/model/resources/resource_type_localizations.json
+++ b/elasticsearch/model/resources/resource_type_localizations.json
@@ -1,0 +1,174 @@
+{
+  "Account": {
+    "en-US": "Account",
+    "de-DE": "Abrechnungsfall"
+  },
+  "AdverseEvent": {
+    "en-US": "Adverse Event",
+    "de-DE": "Unerwünschtes Ereignis"
+  },
+  "AllergyIntolerance": {
+    "en-US": "Allergy / Intolerance",
+    "de-DE": "Allergie / Intoleranz"
+  },
+  "Binary": {
+    "en-US": "Binary Resource",
+    "de-DE": "Binäre Ressource"
+  },
+  "BodyStructure": {
+    "en-US": "Body Structure",
+    "de-DE": "Körperstruktur"
+  },
+  "Bundle": {
+    "en-US": "Bundle",
+    "de-DE": "Bündel / Paket"
+  },
+  "CarePlan": {
+    "en-US": "Care Plan",
+    "de-DE": "Behandlungsplan"
+  },
+  "Composition": {
+    "en-US": "Composition",
+    "de-DE": "Dokument"
+  },
+  "Condition": {
+    "en-US": "Condition",
+    "de-DE": "Diagnose / Erkrankung"
+  },
+  "Consent": {
+    "en-US": "Consent",
+    "de-DE": "Einwilligung"
+  },
+  "Coverage": {
+    "en-US": "Coverage",
+    "de-DE": "Versicherungsdeckung"
+  },
+  "Device": {
+    "en-US": "Device",
+    "de-DE": "Gerät / Medizinprodukt"
+  },
+  "DeviceMetric": {
+    "en-US": "Device Metric",
+    "de-DE": "Gerätemetrik"
+  },
+  "DiagnosticReport": {
+    "en-US": "Diagnostic Report",
+    "de-DE": "Befundbericht"
+  },
+  "DocumentReference": {
+    "en-US": "Document Reference",
+    "de-DE": "Dokumentenreferenz"
+  },
+  "Encounter": {
+    "en-US": "Encounter",
+    "de-DE": "Kontakt / Behandlungsfall"
+  },
+  "EvidenceVariable": {
+    "en-US": "Evidence Variable",
+    "de-DE": "Evidenzvariable"
+  },
+  "Extension": {
+    "en-US": "Extension",
+    "de-DE": "Erweiterung"
+  },
+  "FamilyMemberHistory": {
+    "en-US": "Family Member History",
+    "de-DE": "Familienanamnese"
+  },
+  "ImagingStudy": {
+    "en-US": "Imaging Study",
+    "de-DE": "Bildgebungsstudie"
+  },
+  "Library": {
+    "en-US": "Library",
+    "de-DE": "Bibliothek"
+  },
+  "List": {
+    "en-US": "List",
+    "de-DE": "Liste"
+  },
+  "Location": {
+    "en-US": "Location",
+    "de-DE": "Standort / Ort"
+  },
+  "Media": {
+    "en-US": "Media",
+    "de-DE": "Mediendatei"
+  },
+  "Medication": {
+    "en-US": "Medication",
+    "de-DE": "Arzneimittel"
+  },
+  "MedicationAdministration": {
+    "en-US": "Medication Administration",
+    "de-DE": "Arzneimittelverabreichung"
+  },
+  "MedicationRequest": {
+    "en-US": "Medication Request",
+    "de-DE": "Medikamentenverordnung"
+  },
+  "MedicationStatement": {
+    "en-US": "Medication Statement",
+    "de-DE": "Medikamentendokumentation"
+  },
+  "Observation": {
+    "en-US": "Observation",
+    "de-DE": "Beobachtung / Messwert"
+  },
+  "Organization": {
+    "en-US": "Organization",
+    "de-DE": "Organisation"
+  },
+  "Patient": {
+    "en-US": "Patient",
+    "de-DE": "Patient"
+  },
+  "Practitioner": {
+    "en-US": "Practitioner",
+    "de-DE": "Behandelnder / Arzt"
+  },
+  "PractitionerRole": {
+    "en-US": "Practitioner Role",
+    "de-DE": "Rolle des Behandelnden"
+  },
+  "Procedure": {
+    "en-US": "Procedure",
+    "de-DE": "Prozedur / Eingriff"
+  },
+  "Provenance": {
+    "en-US": "Provenance",
+    "de-DE": "Herkunft / Provenienz"
+  },
+  "RelatedPerson": {
+    "en-US": "Related Person",
+    "de-DE": "Bezugsperson / Angehöriger"
+  },
+  "ResearchStudy": {
+    "en-US": "Research Study",
+    "de-DE": "Forschungsstudie"
+  },
+  "RiskAssessment": {
+    "en-US": "Risk Assessment",
+    "de-DE": "Risikoabschätzung"
+  },
+  "ServiceRequest": {
+    "en-US": "Service Request",
+    "de-DE": "Auftragsanforderung"
+  },
+  "Specimen": {
+    "en-US": "Specimen",
+    "de-DE": "Probe / Biomaterial"
+  },
+  "Subscription": {
+    "en-US": "Subscription",
+    "de-DE": "Abonnement"
+  },
+  "Substance": {
+    "en-US": "Substance",
+    "de-DE": "Substanz"
+  },
+  "Task": {
+    "en-US": "Task",
+    "de-DE": "Aufgabe"
+  }
+}

--- a/parceling/scripts/parcel_final_ontology.py
+++ b/parceling/scripts/parcel_final_ontology.py
@@ -4,7 +4,7 @@ import shutil
 from common.util.log.functions import get_logger
 from common.util.project import Project
 
-logger = get_logger(__file__)
+_logger = get_logger(__file__)
 
 
 if __name__ == "__main__":
@@ -14,12 +14,12 @@ if __name__ == "__main__":
 
     project = Project(name=args.project)
 
-    logger.info(f"Parceling the generated ontology for project '{project.name}'")
+    _logger.info(f"Parceling the generated ontology for project '{project.name}'")
 
     ontology_dir = project.output / "merged_ontology"
     temp_ontology_dir = project.output.mkdirs("merged_ontology", "temp")
 
-    logger.info("Generating mapping archive")
+    _logger.info("Generating mapping archive")
     mapping_dir = ontology_dir / "mapping"
     temp_mapping_dir = project.output.mkdirs("merged_ontology", "temp", "mapping")
 
@@ -27,12 +27,9 @@ if __name__ == "__main__":
     shutil.make_archive(str(mapping_dir), "zip", temp_ontology_dir)
     shutil.rmtree(temp_mapping_dir)
 
-    logger.info("Generating backend archive")
+    _logger.info("Generating backend archive")
     temp_backend_dir = project.output.mkdirs("merged_ontology", "temp", "backend")
 
-    shutil.copy(
-        ontology_dir / "profile_tree.json", temp_backend_dir / "profile_tree.json"
-    )
     shutil.copy(
         project.output.terminology / "terminology_systems.json",
         temp_backend_dir / "terminology_systems.json",
@@ -48,22 +45,36 @@ if __name__ == "__main__":
     shutil.make_archive(str(ontology_dir / "backend"), "zip", temp_backend_dir)
     shutil.rmtree(temp_backend_dir)
 
-    logger.info("Generating elastic archive")
+    _logger.info("Generating elastic archive")
     elastic_input_dir = project.input.elastic
     elastic_output_dir = ontology_dir / "elastic"
     temp_elastic_dir = project.output.mkdirs("merged_ontology", "temp", "elastic")
 
-    shutil.copytree(elastic_output_dir, temp_elastic_dir, dirs_exist_ok=True)
-    shutil.copy(
-        elastic_input_dir / "codeable_concept_index.json",
-        temp_elastic_dir / "codeable_concept_index.json",
-    )
-    shutil.copy(
-        elastic_input_dir / "ontology_index.json",
-        temp_elastic_dir / "ontology_index.json",
-    )
+    if elastic_output_dir.is_dir() and any(elastic_output_dir.iterdir()):
+        content_dir = temp_elastic_dir / "content"
+        content_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(elastic_output_dir, content_dir, dirs_exist_ok=True)
+    else:
+        raise FileNotFoundError(f"Missing Elasticsearch index documents @ {repr(elastic_output_dir)}")
+
+    input_index_dir = project.input.elastic / "index"
+    if input_index_dir.is_dir() and any(input_index_dir.iterdir()):
+        index_dir = temp_elastic_dir / "index"
+        index_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(input_index_dir, index_dir, dirs_exist_ok=True)
+    else:
+        _logger.warning("No Elasticsearch index definitions found. Make sure this is correct")
+
+    input_pipeline_dir = project.input.elastic / "pipeline"
+    if input_pipeline_dir.is_dir() and any(input_pipeline_dir.iterdir()):
+        pipeline_dir = temp_elastic_dir / "pipeline"
+        pipeline_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(input_pipeline_dir, pipeline_dir, dirs_exist_ok=True)
+    else:
+        _logger.info("No Elasticsearch pipeline definitions found")
+
     shutil.make_archive(str(elastic_output_dir), "zip", temp_ontology_dir)
     shutil.rmtree(temp_elastic_dir)
 
-    logger.info("Cleaning up output")
+    _logger.info("Cleaning up output")
     shutil.rmtree(temp_ontology_dir)

--- a/projects/fdpg-ontology/input/elastic/index/codeable_concept_index.json
+++ b/projects/fdpg-ontology/input/elastic/index/codeable_concept_index.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    "index": {
+      "max_ngram_diff": 49
+    },
     "analysis": {
       "tokenizer": {
         "edge_ngram_tokenizer": {
@@ -15,6 +18,29 @@
           "type": "edge_ngram",
           "min_gram": 1,
           "max_gram": 50,
+          "token_chars": [
+            "letter",
+            "digit",
+            "punctuation",
+            "custom"
+          ],
+          "custom_token_chars": [
+            "+-_"
+          ]
+        },
+        "ngram_tokenizer": {
+          "type": "ngram",
+          "min_gram": 3,
+          "max_gram": 25,
+          "token_chars": [
+            "letter",
+            "digit"
+          ]
+        },
+        "ngram_tokenizer_include_punctuation": {
+          "type": "ngram",
+          "min_gram": 3,
+          "max_gram": 25,
           "token_chars": [
             "letter",
             "digit",
@@ -45,6 +71,20 @@
             "lowercase"
           ]
         },
+        "ngram_analyzer": {
+          "type": "custom",
+          "tokenizer": "ngram_tokenizer",
+          "filter": [
+            "lowercase"
+          ]
+        },
+        "ngram_analyzer_include_punctuation": {
+          "type": "custom",
+          "tokenizer": "ngram_tokenizer_include_punctuation",
+          "filter": [
+            "lowercase"
+          ]
+        },
         "lowercase_analyzer": {
           "type": "custom",
           "tokenizer": "whitespace_tokenizer",
@@ -64,6 +104,12 @@
             "fields": {
               "keyword": {
                 "type": "keyword"
+              },
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
               }
             },
             "analyzer": "edge_ngram_analyzer_include_punctuation",
@@ -72,7 +118,15 @@
           "display": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           },
           "system": {
             "type": "text",
@@ -92,20 +146,47 @@
           "original": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer_include_punctuation",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           },
           "de": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer_include_punctuation",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           },
           "en": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer_include_punctuation",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           }
         }
       }
+    },
+    "_meta": {
+      "version": "v5.0.0"
     }
   }
 }

--- a/projects/fdpg-ontology/input/elastic/index/ontology_index.json
+++ b/projects/fdpg-ontology/input/elastic/index/ontology_index.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    "index": {
+      "max_ngram_diff": 49
+    },
     "analysis": {
       "tokenizer": {
         "edge_ngram_tokenizer": {
@@ -15,6 +18,29 @@
           "type": "edge_ngram",
           "min_gram": 1,
           "max_gram": 50,
+          "token_chars": [
+            "letter",
+            "digit",
+            "punctuation",
+            "custom"
+          ],
+          "custom_token_chars": [
+            "+-_"
+          ]
+        },
+        "ngram_tokenizer": {
+          "type": "ngram",
+          "min_gram": 3,
+          "max_gram": 25,
+          "token_chars": [
+            "letter",
+            "digit"
+          ]
+        },
+        "ngram_tokenizer_include_punctuation": {
+          "type": "ngram",
+          "min_gram": 3,
+          "max_gram": 25,
           "token_chars": [
             "letter",
             "digit",
@@ -41,6 +67,20 @@
         "edge_ngram_analyzer_include_punctuation": {
           "type": "custom",
           "tokenizer": "edge_ngram_tokenizer_include_punctuation",
+          "filter": [
+            "lowercase"
+          ]
+        },
+        "ngram_analyzer": {
+          "type": "custom",
+          "tokenizer": "ngram_tokenizer",
+          "filter": [
+            "lowercase"
+          ]
+        },
+        "ngram_analyzer_include_punctuation": {
+          "type": "custom",
+          "tokenizer": "ngram_tokenizer_include_punctuation",
           "filter": [
             "lowercase"
           ]
@@ -112,17 +152,41 @@
           "original": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer_include_punctuation",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           },
           "de": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer_include_punctuation",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           },
           "en": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer_include_punctuation",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           }
         }
       },
@@ -182,6 +246,12 @@
         "fields": {
           "keyword": {
             "type": "keyword"
+          },
+          "ngram": {
+            "type": "text",
+            "analyzer": "ngram_analyzer_include_punctuation",
+            "search_analyzer": "lowercase_analyzer",
+            "norms": false
           }
         },
         "analyzer": "edge_ngram_analyzer_include_punctuation",
@@ -210,6 +280,9 @@
       "terminology": {
         "type": "keyword"
       }
+    },
+    "_meta": {
+      "version": "v5.0.0"
     }
   }
 }

--- a/projects/fdpg-ontology/input/elastic/index/profile_index.json
+++ b/projects/fdpg-ontology/input/elastic/index/profile_index.json
@@ -1,0 +1,418 @@
+{
+  "settings": {
+    "index": {
+      "max_ngram_diff": 49,
+      "default_pipeline": "hash_url"
+    },
+    "analysis": {
+      "tokenizer": {
+        "edge_ngram_tokenizer": {
+          "type": "edge_ngram",
+          "min_gram": 1,
+          "max_gram": 50,
+          "token_chars": [
+            "letter",
+            "digit"
+          ]
+        },
+        "edge_ngram_tokenizer_include_punctuation": {
+          "type": "edge_ngram",
+          "min_gram": 1,
+          "max_gram": 50,
+          "token_chars": [
+            "letter",
+            "digit",
+            "punctuation",
+            "custom"
+          ],
+          "custom_token_chars": [
+            "+-_"
+          ]
+        },
+        "ngram_tokenizer": {
+          "type": "ngram",
+          "min_gram": 3,
+          "max_gram": 25,
+          "token_chars": [
+            "letter",
+            "digit"
+          ]
+        },
+        "ngram_tokenizer_include_punctuation": {
+          "type": "ngram",
+          "min_gram": 3,
+          "max_gram": 25,
+          "token_chars": [
+            "letter",
+            "digit",
+            "punctuation",
+            "custom"
+          ],
+          "custom_token_chars": [
+            "+-_"
+          ]
+        },
+        "whitespace_tokenizer": {
+          "type": "simple_pattern_split",
+          "pattern": " "
+        }
+      },
+      "analyzer": {
+        "edge_ngram_analyzer": {
+          "type": "custom",
+          "tokenizer": "edge_ngram_tokenizer",
+          "filter": [
+            "lowercase"
+          ]
+        },
+        "edge_ngram_analyzer_include_punctuation": {
+          "type": "custom",
+          "tokenizer": "edge_ngram_tokenizer_include_punctuation",
+          "filter": [
+            "lowercase"
+          ]
+        },
+        "ngram_analyzer": {
+          "type": "custom",
+          "tokenizer": "ngram_tokenizer",
+          "filter": [
+            "lowercase"
+          ]
+        },
+        "ngram_analyzer_include_punctuation": {
+          "type": "custom",
+          "tokenizer": "ngram_tokenizer_include_punctuation",
+          "filter": [
+            "lowercase"
+          ]
+        },
+        "lowercase_analyzer": {
+          "type": "custom",
+          "tokenizer": "whitespace_tokenizer",
+          "filter": [
+            "lowercase"
+          ]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "availability": {
+        "type": "long",
+        "index": false
+      },
+      "categories": {
+        "properties": {
+          "original": {
+            "type": "keyword"
+          },
+          "localization": {
+            "type": "object",
+            "enabled": false
+          }
+        }
+      },
+      "resource_type": {
+        "properties": {
+          "original": {
+            "type": "keyword"
+          },
+          "localization": {
+            "type": "object",
+            "enabled": false
+          }
+        }
+      },
+      "children": {
+        "properties": {
+          "display": {
+            "properties": {
+              "original": {
+                "type": "text"
+              },
+              "localization": {
+                "type": "object",
+                "enabled": false
+              }
+            }
+          },
+          "url": {
+            "type": "text",
+            "index": false
+          },
+          "id": {
+            "type": "text",
+            "index": false
+          },
+          "selectable": {
+            "type": "boolean",
+            "index": false
+          }
+        }
+      },
+      "parents": {
+        "properties": {
+          "display": {
+            "properties": {
+              "original": {
+                "type": "text"
+              },
+              "localization": {
+                "type": "object",
+                "enabled": false
+              }
+            }
+          },
+          "url": {
+            "type": "text",
+            "index": false
+          },
+          "id": {
+            "type": "text",
+            "index": false
+          },
+          "selectable": {
+            "type": "boolean",
+            "index": false
+          }
+        }
+      },
+      "description": {
+        "properties": {
+          "original": {
+            "type": "text",
+            "analyzer": "edge_ngram_analyzer_include_punctuation",
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
+          },
+          "localization": {
+            "type": "object",
+            "dynamic": "true",
+            "properties": {
+              "de-DE": {
+                "type": "text",
+                "analyzer": "edge_ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "fields": {
+                  "ngram": {
+                    "type": "text",
+                    "analyzer": "ngram_analyzer_include_punctuation",
+                    "search_analyzer": "lowercase_analyzer",
+                    "norms": false
+                  }
+                }
+              },
+              "en-US": {
+                "type": "text",
+                "analyzer": "edge_ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "fields": {
+                  "ngram": {
+                    "type": "text",
+                    "analyzer": "ngram_analyzer_include_punctuation",
+                    "search_analyzer": "lowercase_analyzer",
+                    "norms": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "display": {
+        "properties": {
+          "original": {
+            "type": "text",
+            "analyzer": "edge_ngram_analyzer_include_punctuation",
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
+          },
+          "localization": {
+            "type": "object",
+            "dynamic": "true",
+            "properties": {
+              "de-DE": {
+                "type": "text",
+                "analyzer": "edge_ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "fields": {
+                  "ngram": {
+                    "type": "text",
+                    "analyzer": "ngram_analyzer_include_punctuation",
+                    "search_analyzer": "lowercase_analyzer",
+                    "norms": false
+                  }
+                }
+              },
+              "en-US": {
+                "type": "text",
+                "analyzer": "edge_ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "fields": {
+                  "ngram": {
+                    "type": "text",
+                    "analyzer": "ngram_analyzer_include_punctuation",
+                    "search_analyzer": "lowercase_analyzer",
+                    "norms": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "fields": {
+        "properties": {
+          "display": {
+            "properties": {
+              "original": {
+                "type": "text",
+                "analyzer": "edge_ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "fields": {
+                  "ngram": {
+                    "type": "text",
+                    "analyzer": "ngram_analyzer_include_punctuation",
+                    "search_analyzer": "lowercase_analyzer",
+                    "norms": false
+                  }
+                }
+              },
+              "localization": {
+                "type": "object",
+                "dynamic": "true",
+                "properties": {
+                  "de-DE": {
+                    "type": "text",
+                    "analyzer": "edge_ngram_analyzer_include_punctuation",
+                    "search_analyzer": "lowercase_analyzer",
+                    "fields": {
+                      "ngram": {
+                        "type": "text",
+                        "analyzer": "ngram_analyzer_include_punctuation",
+                        "search_analyzer": "lowercase_analyzer",
+                        "norms": false
+                      }
+                    }
+                  },
+                  "en-US": {
+                    "type": "text",
+                    "analyzer": "edge_ngram_analyzer_include_punctuation",
+                    "search_analyzer": "lowercase_analyzer",
+                    "fields": {
+                      "ngram": {
+                        "type": "text",
+                        "analyzer": "ngram_analyzer_include_punctuation",
+                        "search_analyzer": "lowercase_analyzer",
+                        "norms": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "description": {
+            "properties": {
+              "original": {
+                "type": "text",
+                "analyzer": "edge_ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "fields": {
+                  "ngram": {
+                    "type": "text",
+                    "analyzer": "ngram_analyzer_include_punctuation",
+                    "search_analyzer": "lowercase_analyzer",
+                    "norms": false
+                  }
+                }
+              },
+              "localization": {
+                "type": "object",
+                "dynamic": "true",
+                "properties": {
+                  "de-DE": {
+                    "type": "text",
+                    "analyzer": "edge_ngram_analyzer_include_punctuation",
+                    "search_analyzer": "lowercase_analyzer",
+                    "fields": {
+                      "ngram": {
+                        "type": "text",
+                        "analyzer": "ngram_analyzer_include_punctuation",
+                        "search_analyzer": "lowercase_analyzer",
+                        "norms": false
+                      }
+                    }
+                  },
+                  "en-US": {
+                    "type": "text",
+                    "analyzer": "edge_ngram_analyzer_include_punctuation",
+                    "search_analyzer": "lowercase_analyzer",
+                    "fields": {
+                      "ngram": {
+                        "type": "text",
+                        "analyzer": "ngram_analyzer_include_punctuation",
+                        "search_analyzer": "lowercase_analyzer",
+                        "norms": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "module": {
+        "properties": {
+          "original": {
+            "type": "keyword"
+          },
+          "localization": {
+            "type": "object",
+            "enabled": false
+          }
+        }
+      },
+      "name": {
+        "type": "text",
+        "analyzer": "edge_ngram_analyzer_include_punctuation",
+        "search_analyzer": "lowercase_analyzer",
+        "fields": {
+          "ngram": {
+            "type": "text",
+            "analyzer": "ngram_analyzer_include_punctuation",
+            "search_analyzer": "lowercase_analyzer",
+            "norms": false
+          }
+        }
+      },
+      "selectable": {
+        "type": "boolean",
+        "index": false
+      },
+      "url": {
+        "type": "text",
+        "index": false
+      }
+    },
+    "_meta": {
+      "version": "v5.0.0"
+    }
+  }
+}

--- a/projects/fdpg-ontology/input/elastic/pipeline/hash_url.json
+++ b/projects/fdpg-ontology/input/elastic/pipeline/hash_url.json
@@ -1,0 +1,63 @@
+{
+  "processors": [
+    {
+      "fingerprint": {
+        "fields": [
+          "url"
+        ],
+        "target_field": "fingerprint",
+        "method": "SHA-256"
+      }
+    },
+    {
+      "gsub": {
+        "field": "fingerprint",
+        "pattern": "\\+",
+        "replacement": "-"
+      }
+    },
+    {
+      "gsub": {
+        "field": "fingerprint",
+        "pattern": "/",
+        "replacement": "_"
+      }
+    },
+    {
+      "gsub": {
+        "field": "fingerprint",
+        "pattern": "=+$",
+        "replacement": ""
+      }
+    },
+    {
+      "set": {
+        "field": "_id",
+        "value": "{{fingerprint}}"
+      }
+    },
+    {
+      "foreach": {
+        "field": "children",
+        "ignore_missing": true,
+        "processor": {
+          "pipeline": {
+            "name": "hash_url_relative"
+          }
+        }
+      }
+    },
+    {
+      "foreach": {
+        "field": "parents",
+        "ignore_missing": true,
+        "processor": {
+          "pipeline": {
+            "name": "hash_url_relative"
+          }
+        }
+      }
+    }
+  ]
+}
+

--- a/projects/fdpg-ontology/input/elastic/pipeline/hash_url_relative.json
+++ b/projects/fdpg-ontology/input/elastic/pipeline/hash_url_relative.json
@@ -1,0 +1,35 @@
+{
+  "processors": [
+    {
+      "fingerprint": {
+        "fields": [
+          "_ingest._value.url"
+        ],
+        "target_field": "_ingest._value.id",
+        "method": "SHA-256"
+      }
+    },
+    {
+      "gsub": {
+        "field": "_ingest._value.id",
+        "pattern": "\\+",
+        "replacement": "-"
+      }
+    },
+    {
+      "gsub": {
+        "field": "_ingest._value.id",
+        "pattern": "/",
+        "replacement": "_"
+      }
+    },
+    {
+      "gsub": {
+        "field": "_ingest._value.id",
+        "pattern": "=+$",
+        "replacement": ""
+      }
+    }
+  ]
+}
+

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,7 +33,7 @@ def copy_and_unpack_project_output(pytestconfig) -> Path:
 
         # Copy and unpack ontology archives
         backend_path = os.path.join(tmp_path, "backend.zip")
-        shutil.copyfile(
+        os.symlink(
             project.output.mkdirs("merged_ontology") / "backend.zip", backend_path
         )
         shutil.unpack_archive(backend_path, ontology_dir_path)
@@ -44,12 +44,8 @@ def copy_and_unpack_project_output(pytestconfig) -> Path:
             if file_name.endswith(".sql"):
                 shutil.move(os.path.join(ontology_dir_path, file_name), migration_path)
 
-        dse_dir_path = os.path.join(ontology_dir_path, "dse")
-        os.makedirs(dse_dir_path, exist_ok=True)
-        shutil.move(os.path.join(ontology_dir_path, "profile_tree.json"), dse_dir_path)
-
         mapping_path = os.path.join(tmp_path, "mapping.zip")
-        shutil.copyfile(
+        os.symlink(
             project.output.mkdirs("merged_ontology") / "mapping.zip", mapping_path
         )
         unpacked_dir_path = os.path.join(ontology_dir_path, "mapping")
@@ -75,7 +71,7 @@ def copy_and_unpack_project_output(pytestconfig) -> Path:
         shutil.rmtree(unpacked_dir_path)
 
         # Copy elastic archive
-        shutil.copyfile(
+        os.symlink(
             project.output.mkdirs("merged_ontology") / "elastic.zip",
             os.path.join(tmp_path, "elastic.zip"),
         )

--- a/tests/integration/elastic/conftest.py
+++ b/tests/integration/elastic/conftest.py
@@ -114,7 +114,7 @@ def elastic_url(docker_ip, docker_services, docker_compose_project_name) -> str:
         if status == "exited":
             break
         attempts += 1
-        time.sleep(5)
+        time.sleep(30)
     if attempts == max_attempts:
         raise Exception(f"Service '{service_name}' did not exit in time")
 

--- a/tests/integration/elastic/docker-compose.yml
+++ b/tests/integration/elastic/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.16.1
+    image: docker.elastic.co/elasticsearch/elasticsearch@sha256:5dbf405a97e008f3024cf6f8f4a314d91b765d82954530893dcc13f8e87d21f4 # 8.19.19
     ports:
       - '9200:9200'
       - '9300:9300'
@@ -15,18 +15,24 @@ services:
       node.name: es01
       cluster.name: elasticsearch
       xpack.security.enabled: false
+    volumes:
+      - type: volume
+        source: elastic-data
+        target: /usr/share/elasticsearch/data
 
   elastic-init:
     depends_on:
       - elastic
-    image: ghcr.io/medizininformatik-initiative/dataportal-es-init:1.2
+    image: ghcr.io/medizininformatik-initiative/dataportal-es-init@sha256:6f7b1836fa974a2f9af537517d9344e4839219f5e6724be57735fbf51ec0f341 # 3.0.2
     environment:
       ES_HOST: elastic
-      ONTO_GIT_TAG: v3.0.2-alpha
       MODE: mount # change this to mount when using own generated ontology
-      LOCAL_PATH: /tmp/mounted_onto.zip
+      LOCAL_PATH: /work/mounted_onto.zip
     volumes:
       - type: bind
         source: "../.tmp/elastic.zip"
-        target: "/tmp/mounted_onto.zip"
+        target: "/work/mounted_onto.zip"
         read_only: true
+
+volumes:
+  elastic-data:

--- a/tests/integration/elastic/test_elastic_search.py
+++ b/tests/integration/elastic/test_elastic_search.py
@@ -2,6 +2,7 @@ import json
 from string import Template
 from typing import Mapping, Any
 
+import pytest
 import requests
 
 from common.util.test.functions import mismatch_str
@@ -67,3 +68,102 @@ def test_criterion_term_code_search(
     assert actual_selectable == expected_selectable, mismatch_str(
         "selectable", actual_selectable, expected_selectable
     )
+
+
+def _query_es(url: str, query: Mapping[str, Any]) -> tuple[int, list[Any]]:
+    response = requests.post(f"{url}/_search", json=query)
+    response.raise_for_status()
+    hits = response.json().get("hits", [])
+    hits_total = hits.get("total", {}).get("value")
+    return hits_total, hits
+
+
+@pytest.mark.parametrize(
+    argnames=["resource_type"],
+    argvalues=[pytest.param("Condition")],
+)
+def test_profile_search_by_resource_type(
+    resource_type: str,
+    elastic_url,
+):
+    query = {"query": {"term": {"resource_type.original": resource_type}}}
+    hits_total, hits = _query_es(f"{elastic_url}/profile", query)
+
+    assert hits_total > 0, "Expected at least one match for the search query"
+    assert hits["hits"][0]["_source"]["resource_type"]["original"] == resource_type
+
+
+@pytest.mark.parametrize(
+    argnames=["module"],
+    argvalues=[
+        pytest.param("modul-medikation", id="medication"),
+    ],
+)
+def test_profile_search_by_module(
+    module: str,
+    elastic_url,
+):
+    query = {
+        "query": {
+            "term": {
+                "module.original": module,
+            }
+        }
+    }
+    hits_total, hits = _query_es(f"{elastic_url}/profile", query)
+
+    assert hits_total > 0, "Expected at least one match for the search query"
+    assert hits["hits"][0]["_source"]["module"]["original"] == module
+
+
+@pytest.mark.parametrize(
+    argnames=["name"],
+    argvalues=[pytest.param("MII_PR_Fall_KontaktGesundheitseinrichtung")],
+)
+def test_profile_search_by_name(
+    name: str,
+    elastic_url,
+):
+    query = {"query": {"match": {"name": name}}}
+    hits_total, hits = _query_es(f"{elastic_url}/profile", query)
+
+    assert hits_total > 0, "Expected at least one match for the search query"
+    assert hits["hits"][0]["_source"]["name"] == name
+
+
+@pytest.mark.parametrize(
+    argnames=["description", "best_match"],
+    argvalues=[
+        pytest.param(
+            "Medikation, die angesetzt, geplant oder verabreicht",
+            "https://www.medizininformatik-initiative.de/fhir/core/modul-medikation/StructureDefinition/Medication",
+            id="medication-de",
+        ),
+        pytest.param(
+            "drug or formulation",
+            "https://www.medizininformatik-initiative.de/fhir/core/modul-medikation/StructureDefinition/Medication",
+            id="medication-en",
+        ),
+    ],
+)
+def test_profile_search_by_description(
+    description: str,
+    best_match: str,
+    elastic_url,
+):
+    query = {
+        "query": {
+            "multi_match": {
+                "fields": [
+                    "description.original",
+                    "description.localization.de-DE",
+                    "description.localization.en-US",
+                ],
+                "query": description,
+            }
+        }
+    }
+    hits_total, hits = _query_es(f"{elastic_url}/profile", query)
+
+    assert hits_total > 0, "Expected at least one match for the search query"
+    assert hits["hits"][0]["_source"]["url"] == best_match


### PR DESCRIPTION
DataSelectionExtraction:
  - Update profile tree data model to support index document generation. Profile tree will now
    primarily serve internal purposes since it is no longer needed by the backend and UI due to
    the new index
  - Refactor profile tree construction and drop root and module-level nodes
  - Update details generator due to changes in profile tree generator
  - Fix localization extraction

Elasticsearch:
  - Change Elasticsearch document files file extension to '.ndjson'
  - Update document bulk import file writing
  - Add generation of profile index documents

Projects.FDPG-Ontology:
  - Add elasticsearch index definition files for indexing of profile details
  - Add Pipeline definitions to allow easier retrieval of profile detail documents

Parceling:
  - Update elastic release archive layout: Add separate subdirectories for index
    definitions, pipelines, and documents

Tests.Integration:
  - Change to using symlinks instead of copying release files to save space
  Elastic:
    - Update compose file to support dataportal-es-init image version 3.x.x

CI:
  - Drop profile tree from release artifacts

Closes: #513 