### PR TITLE
Delete flattening 'branch' if leaf has empty select with no children

### DIFF
--- a/flattening/core/flattening.py
+++ b/flattening/core/flattening.py
@@ -154,8 +154,7 @@ def is_polymorphic(element: ElementDefinition) -> bool:
     :return: true if polymorphic
     """
     return (
-        element.type is not None
-        and "[x]" in element.id.split(".")[-1]
+        element.type is not None and "[x]" in element.id.split(".")[-1]
         # len > 1 does not apply as there are polymorphic elements with only one defined type
         # Laboruntersuchung.effective[x]
         # and len(element.type) > 1
@@ -220,6 +219,9 @@ def recontextualize_extension_lookup(
     :return: recontextualized lookup
     """
     res_lookup = {}
+
+    if not ext_lookup:
+        return {}
 
     for key, lookup in ext_lookup.items():
         new_key = key.replace("Extension", element_id)
@@ -288,6 +290,44 @@ def flattening_post_process(
         res[key] = new_el
 
     return dict(sorted(res.items(), key=lambda item: item[0]))
+
+
+def filter_for_invalid_lookup(
+    element_id: str, lookup: Dict[str, FlatteningLookupElement]
+) -> Dict[str, FlatteningLookupElement]:
+    """
+    Returns {} when an element is deemed to be wrong, else returns the lookup.
+    By using this function after each flattening function, deletion can propagate up the tree
+        leaving no flatteningLookup branches without any valid leafs
+    Lookup is correct if the current lookupElement determined by ``element_id``:
+        1. has valid children (referenced children can be found within the lookup)
+        2. has column definition
+        3. has select which contains column definition (example below)
+    :param element_id: id of the element, root of the lookup
+    :param lookup: flatteningLookup with element_id at root
+    :return: {} is of correct structure
+    """
+    lookup_element: FlatteningLookupElement = lookup.get(element_id)
+    if not lookup_element:
+        return {}
+
+    # if at least one referenced children exists
+    if lookup_element and lookup_element.children:
+        for child_id in lookup_element.children:
+            if lookup.get(child_id):
+                return lookup
+        return {}
+
+    # if lookupElement has columns
+    if lookup_element and lookup_element.view_definition.column is not None:
+        return lookup
+
+    # if non-empty select already carries its own content
+    # (e.g. columns wrapped for a polymorphic child like `value[x]:valueCoding`)
+    if lookup_element.view_definition and lookup_element.view_definition.select:
+        return lookup
+
+    return {}
 
 
 class FlatteningLookupGenerator:
@@ -827,7 +867,7 @@ class FlatteningLookupGenerator:
                     self._flatten_extension(element_id=child, profile=profile, **kwargs)
                 )
 
-            return lookup
+            return filter_for_invalid_lookup(element_id, lookup)
         else:
             # extension slices
             lookup = {}
@@ -863,6 +903,8 @@ class FlatteningLookupGenerator:
                             profile=ext_profile,
                             **kwargs,
                         )
+                        if not ext_lookup:
+                            return {}
                         ext_lookup["Extension.value[x]"].parent = "Extension"
                         lookup.update(
                             recontextualize_extension_lookup(
@@ -916,10 +958,11 @@ class FlatteningLookupGenerator:
                         element_id=f"{element.id}.value[x]", profile=profile, **kwargs
                     )
                 )
+
                 flat_ext_el.children = [f"{element.id}.value[x]"]
                 lookup.update({element_id: flat_ext_el})
 
-            return lookup
+            return filter_for_invalid_lookup(element_id, lookup)
 
     def _flatten_codeable_concept(
         self,
@@ -1008,7 +1051,7 @@ class FlatteningLookupGenerator:
         polymorphic_parent_id: str,
         type: str = None,
         **kwargs,
-    ) -> Dict[str, FlatteningLookupElement] | None:
+    ) -> Dict[str, FlatteningLookupElement]:
         """
         Helper function for flattening polymorphic children. This is done by flattening the child (coding, quantity, etc.)
         the correct way and then inserting the generated "columns"
@@ -1064,7 +1107,7 @@ class FlatteningLookupGenerator:
                 else get_direct_children_ids(element_id, profile)
             )
             lookup_list.update({element_id: fle})
-            return lookup_list
+            return filter_for_invalid_lookup(element_id, lookup_list)
 
         return {}
 
@@ -1135,19 +1178,18 @@ class FlatteningLookupGenerator:
         flat_ext_parent.children = []
         lookup_list = {}
         for child, child_type in unified_children:
-            flat_ext_parent.children.append(child)
-            lookup_list.update(
-                self._generate_flattening_polymorphic_child(
-                    element_id=child,
-                    profile=profile,
-                    polymorphic_parent_id=element_id,
-                    type=child_type,
-                    **clean_kwargs,
-                )
-            )
+            if el := self._generate_flattening_polymorphic_child(
+                element_id=child,
+                profile=profile,
+                polymorphic_parent_id=element_id,
+                type=child_type,
+                **clean_kwargs,
+            ):
+                flat_ext_parent.children.append(child)
+                lookup_list.update(el)
 
         lookup_list.update({element_id: flat_ext_parent})
-        return lookup_list
+        return filter_for_invalid_lookup(element_id, lookup_list)
 
     def _flatten_identifier(
         self,
@@ -1332,7 +1374,9 @@ class FlatteningLookupGenerator:
         element_type = (
             type
             if type
-            else "Polymorphic" if is_polymorphic(element) else get_element_type(element)
+            else "Polymorphic"
+            if is_polymorphic(element)
+            else get_element_type(element)
         )
 
         if element_type in self.config.excluded_types or element_type is None:
@@ -1345,10 +1389,11 @@ class FlatteningLookupGenerator:
         res: Dict[str, FlatteningLookupElement] = {}
 
         if element_type == "Extension":
-            res = self._flatten_extension(
-                element_id=element_id, profile=profile, type=element_type, **kwargs
+            flat_lookup_els.update(
+                self._flatten_extension(
+                    element_id=element_id, profile=profile, type=element_type, **kwargs
+                )
             )
-            flat_lookup_els.update(res)
         else:
             match element_type:
                 case x if x in GENERIC_COMPLEX_TYPES:
@@ -1422,9 +1467,14 @@ class FlatteningLookupGenerator:
             else:
                 ext_flattening_lookup_elements = {}
 
-            flat_lookup_els.update({**res, **ext_flattening_lookup_elements})
+            if res:
+                flat_lookup_els.update(res)
+            if ext_flattening_lookup_elements:
+                flat_lookup_els.update(ext_flattening_lookup_elements)
 
-        return flat_lookup_els
+            # flat_lookup_els.update({**res, **ext_flattening_lookup_elements})
+
+        return filter_for_invalid_lookup(element_id, flat_lookup_els)
 
     def generate_flattening_lookup_for_profile(
         self,

--- a/tests/integration/flattening/test_flattening.py
+++ b/tests/integration/flattening/test_flattening.py
@@ -231,3 +231,50 @@ def test_lookup_file_validity(flattening_lookup: Path, package_manager):
             errors.append(exc)
     if errors:
         raise ExceptionGroup(f"Flattening lookup file is invalid", errors)
+
+
+def _assert_profile_with_no_empty_select_without_children(lookup: FlatteningLookup):
+    """
+    Per the "How to work with a lookup file" section of ``flattening/README.md``, a lookup element's ``.children``
+    are inserted into its own ``viewDefinition.select`` array when a ``ViewDefinition`` is built. An empty
+    ``select`` is therefore only meaningful if the element has at least one child which actually resolves to an
+    element in the lookup - otherwise the generated ``ViewDefinition`` ends up with a ``select`` entry that is
+    never filled (see issue with ``DiagnosticReport.extension:related-report.value[x]`` in
+    https://www.medizininformatik-initiative.de/fhir/ext/modul-patho/StructureDefinition/mii-pr-patho-report).
+    Elements using ``column`` instead of ``select`` (primitive leaves) are not affected by this rule, and neither
+    are elements whose ``select`` already carries content (e.g. primitively-typed polymorphic children).
+    """
+    errors = []
+    for elem_id, elem in lookup.elements.items():
+        vd = elem.view_definition
+        if vd is None or vd.select is None or len(vd.select) > 0:
+            continue
+        try:
+            assert elem.children, (
+                f"Lookup element {repr(elem_id)} has an empty 'select' and no 'children'"
+            )
+            assert any(child_id in lookup.elements for child_id in elem.children), (
+                f"Lookup element {repr(elem_id)} has an empty 'select' and lists children {elem.children!r}, "
+                f"but none of them resolve to an element in the lookup"
+            )
+        except AssertionError as err:
+            errors.append(err)
+    if errors:
+        raise ExceptionGroup(
+            f"Lookup for profile {repr(lookup.url)} contains elements with a dangling empty 'select'", errors
+        )
+
+
+def test_lookup_file_no_empty_select_without_children(flattening_lookup: Path):
+    with flattening_lookup.open(mode="r", encoding="utf-8") as f:
+        flattening_lookups = FlatteningLookupListTA.validate_json(f.read())
+    errors = []
+    for lookup in flattening_lookups:
+        try:
+            _assert_profile_with_no_empty_select_without_children(lookup)
+        except Exception as exc:
+            errors.append(exc)
+    if errors:
+        raise ExceptionGroup(
+            "Flattening lookup file contains elements with a dangling empty 'select'", errors
+        )

--- a/tests/unit/flattening/test_flattening.py
+++ b/tests/unit/flattening/test_flattening.py
@@ -15,8 +15,124 @@ from flattening.core.flattening import (
     flattening_post_process,
     ViewDefinitionSelect,
     FlatteningLookupGenerator,
+    filter_for_invalid_lookup,
 )
 from flattening.model.FlatteningLookupModels import FlatteningLookup
+
+
+@pytest.mark.parametrize(
+    argnames="element_id, lookup, expected",
+    argvalues=[
+        pytest.param(
+            "Observation.extension:foo",
+            {},
+            {},
+            id="element_id missing from lookup -> dropped",
+        ),
+        pytest.param(
+            "Condition.code.coding:icd10-gm.code",
+            {
+                "Condition.code.coding:icd10-gm.code": FlatteningLookupElement(
+                    view_definition=ViewDefinitionSnippet(
+                        column=[
+                            ViewDefinitionColumn(
+                                name="Condition_code_codingIcd10gm_code",
+                                path="code",
+                                type="code",
+                            )
+                        ]
+                    ),
+                ),
+            },
+            "unchanged",
+            id="primitive leaf with top-level column, no children -> kept",
+        ),
+        pytest.param(
+            # Regression for the "Account.coverage.extension:Abrechnungsart.value[x]:valueCoding"
+            # case: a polymorphic child whose columns are wrapped inside `select` (as produced by
+            # `_generate_flattening_polymorphic_child`) instead of a top-level `column`, and which
+            # has no `children` of its own. This used to be wrongly treated as "nothing to
+            # contribute" and dropped, which cascaded upward and deleted the whole extension chain.
+            "Account.coverage.extension:Abrechnungsart.value[x]:valueCoding",
+            {
+                "Account.coverage.extension:Abrechnungsart.value[x]:valueCoding": FlatteningLookupElement(
+                    view_definition=ViewDefinitionSnippet(
+                        for_each_or_null="value.ofType(Coding)",
+                        select=[
+                            ViewDefinitionSelect(
+                                column=[
+                                    ViewDefinitionColumn(
+                                        name="Account_coverage_extensionAbrechnungsart_value_X_Valuecoding_system",
+                                        path="system",
+                                        type="uri",
+                                    )
+                                ]
+                            )
+                        ],
+                    ),
+                ),
+            },
+            "unchanged",
+            id="polymorphic leaf with non-empty select, no children -> kept",
+        ),
+        pytest.param(
+            "Observation.effective[x].extension:QuelleKlinischesBezugsdatum",
+            {
+                "Observation.effective[x].extension:QuelleKlinischesBezugsdatum": FlatteningLookupElement(
+                    view_definition=ViewDefinitionSnippet(select=[]),
+                    children=["Observation.effective[x].extension:QuelleKlinischesBezugsdatum.value[x]"],
+                ),
+                "Observation.effective[x].extension:QuelleKlinischesBezugsdatum.value[x]": FlatteningLookupElement(
+                    view_definition=ViewDefinitionSnippet(select=[]),
+                    children=[
+                        "Observation.effective[x].extension:QuelleKlinischesBezugsdatum.value[x]:valueCoding"
+                    ],
+                ),
+                "Observation.effective[x].extension:QuelleKlinischesBezugsdatum.value[x]:valueCoding": FlatteningLookupElement(
+                    view_definition=ViewDefinitionSnippet(
+                        select=[ViewDefinitionSelect(column=[])]
+                    ),
+                ),
+            },
+            "unchanged",
+            id="empty select + children, child resolves -> kept",
+        ),
+        pytest.param(
+            # This is the original issue: an extension's value[x] has no defined/assumed types
+            # (e.g. `DiagnosticReport.extension:related-report.value[x]` for
+            # `workflow-relatedArtifact`), so it ends up with an empty `select` and either no
+            # children or children that don't resolve to anything in the lookup. Keeping it
+            # produces a `ViewDefinition.select` entry that is never filled.
+            "DiagnosticReport.extension:related-report.value[x]",
+            {
+                "DiagnosticReport.extension:related-report.value[x]": FlatteningLookupElement(
+                    view_definition=ViewDefinitionSnippet(select=[]),
+                ),
+            },
+            {},
+            id="empty select, no children -> dropped (the original #523 bug)",
+        ),
+        pytest.param(
+            "DiagnosticReport.extension:related-report.value[x]",
+            {
+                "DiagnosticReport.extension:related-report.value[x]": FlatteningLookupElement(
+                    view_definition=ViewDefinitionSnippet(select=[]),
+                    children=["DiagnosticReport.extension:related-report.value[x]:valueCoding"],
+                ),
+                # the referenced child never made it into the lookup (e.g. it was excluded or
+                # dropped further down the chain)
+            },
+            {},
+            id="empty select, children present but none resolve -> dropped",
+        ),
+    ],
+)
+def test_filter_for_empty_select(element_id, lookup, expected):
+    result = filter_for_invalid_lookup(element_id, lookup)
+    if expected == "unchanged":
+        assert result == lookup
+    else:
+        assert result == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
flattening:
- LookupElements with empty select attribute and no children (or non-resolvable child ids) will be excluded from flatteningLookup.json.
- Deletion propagates upward until an element with columns or valid children is found
- Add integration test to detect empty selects in generated flatteningLookup
- Add unit test